### PR TITLE
Feature/start slutt dato sync

### DIFF
--- a/app/src/components/ViewEvent/ViewEventContainer.tsx
+++ b/app/src/components/ViewEvent/ViewEventContainer.tsx
@@ -28,7 +28,6 @@ import {
 import { useNotification } from '../NotificationHandler/NotificationHandler';
 import { stringifyEmail } from 'src/types/email';
 import { hasPermission, readPermission } from 'src/auth';
-import { Link } from 'react-router-dom';
 import { BlockLink } from '../Common/BlockLink/BlockLink';
 
 export const ViewEventContainer = () => {

--- a/app/src/types/date-time.ts
+++ b/app/src/types/date-time.ts
@@ -5,6 +5,8 @@ import {
   parseDate,
   EditDate,
   stringifyDate,
+  datesInOrder,
+  isSameDate,
 } from './date';
 import {
   ITime,
@@ -13,6 +15,7 @@ import {
   ITimeContract,
   EditTime,
   deserializeTime,
+  timesInOrder,
 } from './time';
 import { isOk, Result } from './validation';
 import { isAfter } from 'date-fns';
@@ -73,7 +76,16 @@ export const isInOrder = ({
   first: IDateTime;
   last: IDateTime;
 }) => {
-  return first.date.year < last.date.year;
+  if (datesInOrder({ first: first.date, last: last.date })) {
+    return true;
+  }
+  if (
+    isSameDate(first.date, last.date) &&
+    timesInOrder({ first: first.time, last: last.time })
+  ) {
+    return true;
+  }
+  return false;
 };
 
 export const toDate = ({ date, time }: IDateTime) =>

--- a/app/src/types/date-time.ts
+++ b/app/src/types/date-time.ts
@@ -66,6 +66,16 @@ export const isInTheFuture = ({ date, time }: IDateTime) => {
   return isAfter(toDate({ date, time }), now);
 };
 
+export const isInOrder = ({
+  first,
+  last,
+}: {
+  first: IDateTime;
+  last: IDateTime;
+}) => {
+  return first.date.year < last.date.year;
+};
+
 export const toDate = ({ date, time }: IDateTime) =>
   new Date(date.year, date.month - 1, date.day, time.hour, time.minute);
 

--- a/app/src/types/date.ts
+++ b/app/src/types/date.ts
@@ -42,12 +42,32 @@ export const dateAsText = (date: IDate) => {
   );
 };
 
-export const isSameDate = (date: IDate, otherDate: IDate) => {
-  return (
-    date.year === otherDate.year &&
-    date.month === otherDate.month &&
-    date.day === otherDate.day
-  );
+export const isSameDate = (date: IDate, otherDate: IDate) =>
+  date.year === otherDate.year &&
+  date.month === otherDate.month &&
+  date.day === otherDate.day;
+
+export const datesInOrder = ({
+  first,
+  last,
+}: {
+  first: IDate;
+  last: IDate;
+}) => {
+  if (first.year < last.year) {
+    return true;
+  }
+  if (first.year === last.year && first.month < last.month) {
+    return true;
+  }
+  if (
+    first.year === last.year &&
+    first.month === last.month &&
+    first.day < last.day
+  ) {
+    return true;
+  }
+  return false;
 };
 
 export const deserializeDate = ({

--- a/app/src/types/time.ts
+++ b/app/src/types/time.ts
@@ -12,7 +12,7 @@ export interface ITime {
 export const parseTime = ([_hour, _minutes]: EditTime): Result<
   EditTime,
   ITime
-  > => {
+> => {
   const hour = Number(_hour);
   const minute = Number(_minutes);
 
@@ -37,3 +37,19 @@ export const deserializeTime = (time: ITimeContract): EditTime => [
   time.hour.toString().padStart(2, '0'),
   time.minute.toString().padStart(2, '0'),
 ];
+
+export const timesInOrder = ({
+  first,
+  last,
+}: {
+  first: ITime;
+  last: ITime;
+}) => {
+  if (first.hour < last.hour) {
+    return true;
+  }
+  if (first.hour === last.hour && first.minute < last.minute) {
+    return true;
+  }
+  return false;
+};


### PR DESCRIPTION
### Denne endringa

Vi flytter sluttdato fram dersom startdato skulle passere - tilsvarende andre vegen, dersom man setter sluttdatoen tilbake før startdato, flytter vi startdato bak også.

### Implementasjon

Vi bruker ein state-reducer-pattern som sett i redux eller useReducer for å beregne ny state. Vi tar inn ein message (`Action`) som seier noko om kva du ønsker å gjere, for eksempel sette startdatoen. `setStartEndDates` funksjonen regner så ut ny `{ start, end }` par som alltid er i "riktig rekkefølge".

Dersom ein eller fleire av desse datoene er ugyldige datoer, blir likevel berre datoen satt direkte.

### Vidare arbeid

Kanskje man heller ønsker at dette berre skal kjøre på `onBlur`? Det er jo litt opp til UX, men det ville i så tilfelle komplisere implementasjonen, trur eg.

Det er ein bug som er forårsaka av denne live oppdateringa: dersom starttid er kl 17 og sluttid klokka 20, vil å endre sluttida til 19 endre starttida til kl 01 på natta. Ikkje sikkert vi bryr oss om dette i første omgang.

Ein anna case er tilfellet kor sluttdato blir flytta fram for å matche startdato. Sjølv om sluttida er etter starttida, vil sluttida blir satt _lik_ starttida. Det krever enno meir logikk for å "berre" sette dato-delen om det er nok, og eventuelt sette tid-delen også om det trengs.