### PR TITLE
Feature/remote data

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "typescript.preferences.importModuleSpecifier": "non-relative",
+    "javascript.preferences.importModuleSpecifier": "non-relative"
+}

--- a/app/.env
+++ b/app/.env
@@ -1,0 +1,1 @@
+NODE_PATH=./

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -7759,7 +7759,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7777,11 +7778,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7794,15 +7797,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7905,7 +7911,8 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7915,6 +7922,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7927,17 +7935,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7954,6 +7965,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -8034,7 +8046,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -8044,6 +8057,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -8119,7 +8133,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -8149,6 +8164,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -8166,6 +8182,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -8204,11 +8221,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         }
@@ -14493,7 +14512,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -14511,11 +14531,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -14528,15 +14550,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -14639,7 +14664,8 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -14649,6 +14675,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -14661,17 +14688,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -14688,6 +14718,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -14768,7 +14799,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -14778,6 +14810,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -14853,7 +14886,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -14883,6 +14917,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -14900,6 +14935,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -14938,11 +14974,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -15229,7 +15267,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -15247,11 +15286,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -15264,15 +15305,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -15375,7 +15419,8 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -15385,6 +15430,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -15397,17 +15443,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -15424,6 +15473,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -15504,7 +15554,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -15514,6 +15565,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -15589,7 +15641,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -15619,6 +15672,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -15636,6 +15690,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -15674,11 +15729,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },

--- a/app/package.json
+++ b/app/package.json
@@ -33,7 +33,10 @@
     "server": "node server.js"
   },
   "eslintConfig": {
-    "extends": "react-app"
+    "extends": "react-app",
+    "rules": {
+      "no-throw-literal": 0
+    }
   },
   "browserslist": {
     "production": [

--- a/app/src/components/CancelParticipant/CancelParticipant.tsx
+++ b/app/src/components/CancelParticipant/CancelParticipant.tsx
@@ -9,7 +9,7 @@ import { stringifyTime } from 'src/types/time';
 import style from './CancelParticipant.module.scss';
 import queryString from 'query-string';
 import { useNotification } from '../NotificationHandler/NotificationHandler';
-import { hasLoaded } from 'src/remote-data';
+import { hasLoaded, isBad } from 'src/remote-data';
 import { viewEventRoute } from 'src/routing';
 
 const useQuery = (key: string) => {
@@ -47,7 +47,7 @@ export const CancelParticipant = () => {
     }
   });
 
-  if (!hasLoaded(remoteEvent)) {
+  if (isBad(remoteEvent)) {
     return (
       <div>
         Ugyldig url!{' '}
@@ -56,6 +56,10 @@ export const CancelParticipant = () => {
         </span>
       </div>
     );
+  }
+
+  if (!hasLoaded(remoteEvent)) {
+    return <div>Laster...</div>;
   }
 
   const event = remoteEvent.data;

--- a/app/src/components/CancelParticipant/CancelParticipant.tsx
+++ b/app/src/components/CancelParticipant/CancelParticipant.tsx
@@ -24,8 +24,8 @@ const useQuery = (key: string) => {
 };
 
 export const CancelParticipant = () => {
-  const { eventId, email: participantEmail } = useParams();
-  const [event] = useEvent(eventId);
+  const { eventId = 'UGYLDIG_URL', email: participantEmail } = useParams();
+  const event = useEvent(eventId);
   const cancellationToken = useQuery('cancellationToken');
   const [wasDeleted, setWasDeleted] = useState(false);
   const { catchAndNotify } = useNotification();

--- a/app/src/components/CancelParticipant/CancelParticipant.tsx
+++ b/app/src/components/CancelParticipant/CancelParticipant.tsx
@@ -9,6 +9,7 @@ import { stringifyTime } from 'src/types/time';
 import style from './CancelParticipant.module.scss';
 import queryString from 'query-string';
 import { useNotification } from '../NotificationHandler/NotificationHandler';
+import { hasLoaded } from 'src/remote-data';
 
 const useQuery = (key: string) => {
   const {
@@ -25,7 +26,7 @@ const useQuery = (key: string) => {
 
 export const CancelParticipant = () => {
   const { eventId = 'UGYLDIG_URL', email: participantEmail } = useParams();
-  const event = useEvent(eventId);
+  const remoteEvent = useEvent(eventId);
   const cancellationToken = useQuery('cancellationToken');
   const [wasDeleted, setWasDeleted] = useState(false);
   const { catchAndNotify } = useNotification();
@@ -43,7 +44,7 @@ export const CancelParticipant = () => {
     }
   });
 
-  if (!event) {
+  if (!hasLoaded(remoteEvent)) {
     return (
       <div>
         Ugyldig url!{' '}
@@ -53,6 +54,8 @@ export const CancelParticipant = () => {
       </div>
     );
   }
+
+  const event = remoteEvent.data;
 
   const CancelledView = () => (
     <>

--- a/app/src/components/EditEvent/EditEventContainer.tsx
+++ b/app/src/components/EditEvent/EditEventContainer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useLayoutEffect } from 'react';
 import React from 'react';
 import {
   parseEvent,
@@ -31,7 +31,7 @@ export const EditEventContainer = () => {
   const history = useHistory();
   const { catchAndNotify } = useNotification();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (hasLoaded(remoteEvent)) {
       setEvent(parseEvent(deserializeEvent(serializeEvent(remoteEvent.data))));
     }
@@ -51,6 +51,7 @@ export const EditEventContainer = () => {
 
   const goToOverview = () => history.push(eventsRoute);
   const goToEvent = () => history.push(viewEventRoute(eventId));
+
   const updateEvent = (editEvent: IEditEvent) =>
     setEvent(parseEvent(editEvent));
 

--- a/app/src/components/EditEvent/EditEventContainer.tsx
+++ b/app/src/components/EditEvent/EditEventContainer.tsx
@@ -5,8 +5,9 @@ import {
   IEditEvent,
   deserializeEvent,
   IEvent,
+  serializeEvent,
 } from 'src/types/event';
-import { putEvent, getEvent, deleteEvent } from 'src/api/arrangementSvc';
+import { putEvent, deleteEvent } from 'src/api/arrangementSvc';
 import { useParams, useHistory } from 'react-router';
 import { isOk, Result } from 'src/types/validation';
 import { EditEvent } from './EditEvent/EditEvent';
@@ -17,25 +18,24 @@ import { Page } from '../Page/Page';
 import style from './EditEventContainer.module.scss';
 import { eventsRoute, viewEventRoute } from 'src/routing';
 import { useNotification } from '../NotificationHandler/NotificationHandler';
+import { useEvent } from 'src/hooks/eventHooks';
+import { hasLoaded } from 'src/remote-data';
 
 export const EditEventContainer = () => {
   useAuthentication();
-  const { eventId } = useParams();
+  const { eventId = 'URL-FEIL' } = useParams();
 
+  const remoteEvent = useEvent(eventId);
   const [event, setEvent] = useState<Result<IEditEvent, IEvent>>();
   const [previewState, setPreviewState] = useState(false);
   const history = useHistory();
   const { catchAndNotify } = useNotification();
 
-  useEffect(
-    catchAndNotify(async () => {
-      if (eventId) {
-        const retrievedEvent = await getEvent(eventId);
-        setEvent(parseEvent(deserializeEvent(retrievedEvent)));
-      }
-    }),
-    [eventId]
-  );
+  useEffect(() => {
+    if (hasLoaded(remoteEvent)) {
+      setEvent(parseEvent(deserializeEvent(serializeEvent(remoteEvent.data))));
+    }
+  }, [remoteEvent]);
 
   if (!event || !eventId) {
     return <div>Loading</div>;

--- a/app/src/components/EditEvent/EditEventContainer.tsx
+++ b/app/src/components/EditEvent/EditEventContainer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useLayoutEffect } from 'react';
+import { useState, useLayoutEffect } from 'react';
 import React from 'react';
 import {
   parseEvent,

--- a/app/src/components/EditEvent/EditEventContainer.tsx
+++ b/app/src/components/EditEvent/EditEventContainer.tsx
@@ -27,38 +27,37 @@ export const EditEventContainer = () => {
   const history = useHistory();
   const { catchAndNotify } = useNotification();
 
-  useEffect(() => {
-    if (eventId) {
-      catchAndNotify(async () => {
+  useEffect(
+    catchAndNotify(async () => {
+      if (eventId) {
         const retrievedEvent = await getEvent(eventId);
         setEvent(parseEvent(deserializeEvent(retrievedEvent)));
-      })();
-    }
-  }, [eventId, catchAndNotify]);
+      }
+    }),
+    [eventId]
+  );
 
   if (!event || !eventId) {
     return <div>Loading</div>;
   }
 
-  const editEventFunction = () =>
-    catchAndNotify(async () => {
-      if (isOk(event)) {
-        const updatedEvent = await putEvent(eventId, event.validValue);
-        setEvent(parseEvent(deserializeEvent(updatedEvent)));
-        history.push(viewEventRoute(eventId));
-      }
-    })();
+  const editEventFunction = catchAndNotify(async () => {
+    if (isOk(event)) {
+      const updatedEvent = await putEvent(eventId, event.validValue);
+      setEvent(parseEvent(deserializeEvent(updatedEvent)));
+      history.push(viewEventRoute(eventId));
+    }
+  });
 
   const goToOverview = () => history.push(eventsRoute);
   const goToEvent = () => history.push(viewEventRoute(eventId));
   const updateEvent = (editEvent: IEditEvent) =>
     setEvent(parseEvent(editEvent));
 
-  const onDeleteEvent = (eventId: string) =>
-    catchAndNotify(async () => {
-      await deleteEvent(eventId);
-      goToOverview();
-    })();
+  const onDeleteEvent = catchAndNotify(async (eventId: string) => {
+    await deleteEvent(eventId);
+    goToOverview();
+  });
 
   const renderEditView = () => (
     <Page>

--- a/app/src/components/NotificationHandler/NotificationHandler.tsx
+++ b/app/src/components/NotificationHandler/NotificationHandler.tsx
@@ -47,10 +47,16 @@ export const NotificationHandler = ({ children }: IProps) => {
  */
 export const useNotification = () => {
   const notify: NotifyUser = useCallback(useContext(NotificationContext), []);
-  const catchAndNotify = useCallback(
-    (f: () => void) => async () => {
+  function _catchAndNotify<T>(f: () => void): () => void;
+  function _catchAndNotify<T>(f: (x: T) => void): (x: T) => void;
+  function _catchAndNotify<T>(x?: T): any {
+    return async (f: (x?: T) => Promise<void>) => {
       try {
-        await f();
+        if (x) {
+          await f(x);
+        } else {
+          await f();
+        }
       } catch (e) {
         if (isNotification(e)) {
           notify(e);
@@ -58,9 +64,9 @@ export const useNotification = () => {
           throw e;
         }
       }
-    },
-    [notify]
-  );
+    };
+  }
+  const catchAndNotify = useCallback(_catchAndNotify, [notify]);
   return { notify, catchAndNotify };
 };
 

--- a/app/src/components/NotificationHandler/NotificationHandler.tsx
+++ b/app/src/components/NotificationHandler/NotificationHandler.tsx
@@ -47,16 +47,18 @@ export const NotificationHandler = ({ children }: IProps) => {
  */
 export const useNotification = () => {
   const notify: NotifyUser = useCallback(useContext(NotificationContext), []);
-  function _catchAndNotify<T>(f: () => Promise<void>): () => void;
-  function _catchAndNotify<T>(f: (x: T) => Promise<void>): (x: T) => void;
-  function _catchAndNotify<T>(f: (x?: T) => Promise<void>): any {
-    return (x?: T) => {
+  function _catchAndNotify<T, R>(f: () => Promise<R>): () => Promise<R>;
+  function _catchAndNotify<T, R>(f: (x: T) => Promise<R>): (x: T) => Promise<R>;
+  function _catchAndNotify<T, R>(
+    f: (x?: T) => Promise<R>
+  ): (x?: T) => Promise<R> {
+    return (x?: T) =>
       f(x).catch(e => {
         if (isNotification(e)) {
           notify(e);
         }
+        return Promise.reject(e);
       });
-    };
   }
   const catchAndNotify = useCallback(_catchAndNotify, [notify]);
   return { notify, catchAndNotify };

--- a/app/src/components/NotificationHandler/NotificationHandler.tsx
+++ b/app/src/components/NotificationHandler/NotificationHandler.tsx
@@ -47,23 +47,15 @@ export const NotificationHandler = ({ children }: IProps) => {
  */
 export const useNotification = () => {
   const notify: NotifyUser = useCallback(useContext(NotificationContext), []);
-  function _catchAndNotify<T>(f: () => void): () => void;
-  function _catchAndNotify<T>(f: (x: T) => void): (x: T) => void;
-  function _catchAndNotify<T>(f: (x?: T) => void): any {
-    return async (x?: T) => {
-      try {
-        if (x) {
-          await f(x);
-        } else {
-          await f();
-        }
-      } catch (e) {
+  function _catchAndNotify<T>(f: () => Promise<void>): () => void;
+  function _catchAndNotify<T>(f: (x: T) => Promise<void>): (x: T) => void;
+  function _catchAndNotify<T>(f: (x?: T) => Promise<void>): any {
+    return (x?: T) => {
+      f(x).catch(e => {
         if (isNotification(e)) {
           notify(e);
-        } else {
-          throw e;
         }
-      }
+      });
     };
   }
   const catchAndNotify = useCallback(_catchAndNotify, [notify]);

--- a/app/src/components/NotificationHandler/NotificationHandler.tsx
+++ b/app/src/components/NotificationHandler/NotificationHandler.tsx
@@ -49,8 +49,8 @@ export const useNotification = () => {
   const notify: NotifyUser = useCallback(useContext(NotificationContext), []);
   function _catchAndNotify<T>(f: () => void): () => void;
   function _catchAndNotify<T>(f: (x: T) => void): (x: T) => void;
-  function _catchAndNotify<T>(x?: T): any {
-    return async (f: (x?: T) => Promise<void>) => {
+  function _catchAndNotify<T>(f: (x?: T) => void): any {
+    return async (x?: T) => {
       try {
         if (x) {
           await f(x);

--- a/app/src/components/ViewEvent/ViewEventContainer.tsx
+++ b/app/src/components/ViewEvent/ViewEventContainer.tsx
@@ -29,7 +29,7 @@ import { useNotification } from '../NotificationHandler/NotificationHandler';
 import { stringifyEmail } from 'src/types/email';
 import { hasPermission, readPermission } from 'src/auth';
 import { BlockLink } from '../Common/BlockLink/BlockLink';
-import { hasLoaded } from 'src/remote-data';
+import { hasLoaded, isBad } from 'src/remote-data';
 
 export const ViewEventContainer = () => {
   const { eventId = '0' } = useParams();
@@ -46,6 +46,10 @@ export const ViewEventContainer = () => {
   );
   const { createdEventId } = useRecentlyCreatedEvent();
   const hasRecentlyCreatedThisEvent = eventId === createdEventId;
+
+  if (isBad(remoteEvent)) {
+    return <div>{remoteEvent.userMessage}</div>;
+  }
 
   if (!hasLoaded(remoteEvent)) {
     return <div>Loading</div>;

--- a/app/src/components/ViewEvent/ViewEventContainer.tsx
+++ b/app/src/components/ViewEvent/ViewEventContainer.tsx
@@ -29,6 +29,7 @@ import { useNotification } from '../NotificationHandler/NotificationHandler';
 import { stringifyEmail } from 'src/types/email';
 import { hasPermission, readPermission } from 'src/auth';
 import { BlockLink } from '../Common/BlockLink/BlockLink';
+import { hasLoaded, isLoading } from 'src/remote-data';
 
 export const ViewEventContainer = () => {
   const { eventId = '0' } = useParams();
@@ -39,14 +40,18 @@ export const ViewEventContainer = () => {
   const history = useHistory();
   const { catchAndNotify } = useNotification();
 
-  const event = useEvent(eventId);
-  const timeLeft = useTimeLeft(event && event.openForRegistrationTime);
+  const remoteEvent = useEvent(eventId);
+  const timeLeft = useTimeLeft(
+    hasLoaded(remoteEvent) && remoteEvent.data.openForRegistrationTime
+  );
   const { createdEventId } = useRecentlyCreatedEvent();
   const hasRecentlyCreatedThisEvent = eventId === createdEventId;
 
-  if (!event) {
+  if (!hasLoaded(remoteEvent)) {
     return <div>Loading</div>;
   }
+
+  const event = remoteEvent.data;
 
   const addParticipant = catchAndNotify(async () => {
     if (isOk(participant)) {

--- a/app/src/components/ViewEvent/ViewEventContainer.tsx
+++ b/app/src/components/ViewEvent/ViewEventContainer.tsx
@@ -29,7 +29,7 @@ import { useNotification } from '../NotificationHandler/NotificationHandler';
 import { stringifyEmail } from 'src/types/email';
 import { hasPermission, readPermission } from 'src/auth';
 import { BlockLink } from '../Common/BlockLink/BlockLink';
-import { hasLoaded, isLoading } from 'src/remote-data';
+import { hasLoaded } from 'src/remote-data';
 
 export const ViewEventContainer = () => {
   const { eventId = '0' } = useParams();

--- a/app/src/components/ViewEvent/ViewEventContainer.tsx
+++ b/app/src/components/ViewEvent/ViewEventContainer.tsx
@@ -15,8 +15,6 @@ import {
 } from 'src/types/participant';
 import { Result, isOk } from 'src/types/validation';
 import { useTimeLeft } from 'src/hooks/timeleftHooks';
-import { Page } from '../Page/Page';
-import { Button } from '../Common/Button/Button';
 import {
   cancelParticipantRoute,
   viewEventRoute,
@@ -24,12 +22,14 @@ import {
   editEventRoute,
   confirmParticipantRoute,
 } from 'src/routing';
-import { useNotification } from '../NotificationHandler/NotificationHandler';
 import { stringifyEmail, parseEmail } from 'src/types/email';
 import { hasPermission, readPermission } from 'src/auth';
-import { BlockLink } from '../Common/BlockLink/BlockLink';
 import { hasLoaded, isBad } from 'src/remote-data';
-import { ValidatedTextInput } from '../Common/ValidatedTextInput/ValidatedTextInput';
+import { useNotification } from 'src/components/NotificationHandler/NotificationHandler';
+import { ValidatedTextInput } from 'src/components/Common/ValidatedTextInput/ValidatedTextInput';
+import { Page } from 'src/components/Page/Page';
+import { BlockLink } from 'src/components/Common/BlockLink/BlockLink';
+import { Button } from 'src/components/Common/Button/Button';
 
 export const ViewEventContainer = () => {
   const { eventId = '0' } = useParams();

--- a/app/src/components/ViewEvent/ViewEventContainer.tsx
+++ b/app/src/components/ViewEvent/ViewEventContainer.tsx
@@ -39,7 +39,7 @@ export const ViewEventContainer = () => {
   const history = useHistory();
   const { catchAndNotify } = useNotification();
 
-  const [event] = useEvent(eventId);
+  const event = useEvent(eventId);
   const timeLeft = useTimeLeft(event && event.openForRegistrationTime);
   const { createdEventId } = useRecentlyCreatedEvent();
   const hasRecentlyCreatedThisEvent = eventId === createdEventId;

--- a/app/src/components/ViewEvents/ViewEventsContainer.tsx
+++ b/app/src/components/ViewEvents/ViewEventsContainer.tsx
@@ -11,7 +11,7 @@ import {
   parseEvent,
   IEditEvent,
 } from 'src/types/event';
-import { isOk, Result } from 'src/types/validation';
+import { isOk, Result, isBad } from 'src/types/validation';
 import { Link } from 'react-router-dom';
 import { Page } from '../Page/Page';
 import { useNotification } from '../NotificationHandler/NotificationHandler';
@@ -71,7 +71,14 @@ export const ViewEventsContainer = () => {
               />
             );
           }
-          return <div key={i}>Event with id {x} is no good </div>;
+          return (
+            <div key={i}>
+              Event with id {x} is no good{' '}
+              {eventFromMap &&
+                isBad(eventFromMap) &&
+                eventFromMap.errors.map(x => x.message).join(', ')}
+            </div>
+          );
         })}
       </div>
     </Page>

--- a/app/src/components/ViewEvents/ViewEventsContainer.tsx
+++ b/app/src/components/ViewEvents/ViewEventsContainer.tsx
@@ -33,13 +33,14 @@ const useEvents = () => {
   >();
   const { catchAndNotify } = useNotification();
 
-  useEffect(() => {
+  useEffect(
     catchAndNotify(async () => {
       const events = await getEvents();
       const eventsMap = toParsedEventsMap(events);
       setEvents(eventsMap);
-    })();
-  }, [catchAndNotify]);
+    }),
+    []
+  );
 
   return events;
 };

--- a/app/src/components/ViewEvents/ViewEventsContainer.tsx
+++ b/app/src/components/ViewEvents/ViewEventsContainer.tsx
@@ -10,8 +10,6 @@ import { hasLoaded } from 'src/remote-data';
 export const ViewEventsContainer = () => {
   const events = useEvents();
 
-  const eventsKeys = Array.from(events.keys());
-
   return (
     <Page>
       <div className={style.header}>
@@ -19,14 +17,13 @@ export const ViewEventsContainer = () => {
         <AddEventButton />
       </div>
       <div>
-        {eventsKeys.map((x, i) => {
-          const eventFromMap = events.get(x);
-          if (eventFromMap !== undefined && hasLoaded(eventFromMap)) {
+        {[...events].map(([id, event]) => {
+          if (hasLoaded(event)) {
             return (
               <EventListElement
-                key={x}
-                event={eventFromMap.data}
-                onClickRoute={editEventRoute(x)}
+                key={id}
+                event={event.data}
+                onClickRoute={editEventRoute(id)}
               />
             );
           }

--- a/app/src/hooks/eventHooks.ts
+++ b/app/src/hooks/eventHooks.ts
@@ -7,30 +7,24 @@ import { cachedRemoteData } from 'src/remote-data';
 const eventCache = cachedRemoteData<string, IEvent>();
 
 export const useEvent = (id: string) => {
-  const event = eventCache.useOne({
+  return eventCache.useOne({
     key: id,
     fetcher: useCallback(async () => {
       const retrievedEvent = await getEvent(id);
       return maybeParseEvent(retrievedEvent);
     }, [id]),
   });
-
-  return event;
 };
 
 export const useEvents = () => {
-  const events = eventCache.useAll(
+  return eventCache.useAll(
     useCallback(async () => {
       const eventContracts = await getEvents();
-      const events: [string, IEvent][] = eventContracts.map(
-        ({ id, ...event }) => {
-          return [id, maybeParseEvent(event)];
-        }
-      );
-      return events;
+      return eventContracts.map(({ id, ...event }) => {
+        return [id, maybeParseEvent(event)];
+      });
     }, [])
   );
-  return events;
 };
 
 export const useCreatedEvents = (): {

--- a/app/src/hooks/eventHooks.ts
+++ b/app/src/hooks/eventHooks.ts
@@ -29,7 +29,7 @@ export const useEvent = (id: string) => {
 };
 
 export const useEvents = () => {
-  const events = eventCache.useMany(
+  const events = eventCache.useAll(
     useCallback(async () => {
       const eventContracts = await getEvents();
       const events: [string, IEvent][] = eventContracts.mapIf(

--- a/app/src/hooks/eventHooks.ts
+++ b/app/src/hooks/eventHooks.ts
@@ -9,18 +9,19 @@ export const useEvent = (id: string | undefined): [IEvent | undefined] => {
   const [event, setEvent] = useState<IEvent | undefined>(undefined);
   const { catchAndNotify } = useNotification();
 
-  useEffect(() => {
-    if (id) {
-      catchAndNotify(async () => {
+  useEffect(
+    catchAndNotify(async () => {
+      if (id) {
         const retrievedEvent = await getEvent(id);
         const deserializedEvent = deserializeEvent(retrievedEvent);
         const domainEvent = parseEvent(deserializedEvent);
         if (isOk(domainEvent)) {
           setEvent(domainEvent.validValue);
         }
-      })();
-    }
-  }, [id, catchAndNotify]);
+      }
+    }),
+    [id]
+  );
 
   return [event];
 };

--- a/app/src/hooks/eventHooks.ts
+++ b/app/src/hooks/eventHooks.ts
@@ -5,7 +5,7 @@ import { isOk } from 'src/types/validation';
 import { useNotification } from 'src/components/NotificationHandler/NotificationHandler';
 import { useLocalStorage } from './localStorage';
 
-export const useEvent = (id: string | undefined): [IEvent | undefined] => {
+export const useEvent = (id: string): IEvent | undefined => {
   const [event, setEvent] = useState<IEvent | undefined>(undefined);
   const { catchAndNotify } = useNotification();
 
@@ -23,7 +23,7 @@ export const useEvent = (id: string | undefined): [IEvent | undefined] => {
     [id]
   );
 
-  return [event];
+  return event;
 };
 
 export const useRecentlyCreatedEvent = (): {

--- a/app/src/hooks/timeleftHooks.ts
+++ b/app/src/hooks/timeleftHooks.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { calculateTimeLeft } from 'src/utils/timeleft';
 
-export const useTimeLeft = (time: Date | undefined) => {
+export const useTimeLeft = (time: Date | false) => {
   const [timeLeft, setTimeLeft] = useState({
     days: 0,
     hours: 0,

--- a/app/src/remote-data.ts
+++ b/app/src/remote-data.ts
@@ -34,7 +34,7 @@ export function isPending<T>(data: RemoteData<T>): data is Pending<T> {
   return data.status === 'PENDING';
 }
 
-export function isOk<T>(data: RemoteData<T>): data is Ok<T> {
+export function hasLoaded<T>(data: RemoteData<T>): data is Ok<T> {
   return data.status === 'OK';
 }
 
@@ -64,7 +64,7 @@ export const useUpdateRemoteData = <T, P>(
   const updateRemoteData = useCallback(
     (param: P) => {
       setRemoteData(remoteData => {
-        if (isOk(remoteData)) {
+        if (hasLoaded(remoteData)) {
           return {
             status: 'PENDING',
             staleData: remoteData.data,
@@ -73,6 +73,7 @@ export const useUpdateRemoteData = <T, P>(
         if (isError(remoteData) || isNotRequested(remoteData)) {
           return { status: 'LOADING' };
         }
+        return remoteData;
       });
       fetcher(param)
         .then(data => setRemoteData({ status: 'OK', data }))

--- a/app/src/remote-data.ts
+++ b/app/src/remote-data.ts
@@ -56,6 +56,15 @@ export function isBad<T>(data: RemoteData<T>): data is Bad {
 export function cachedRemoteData<Key extends string, T>() {
   let cache: Map<Key, RemoteData<T>> = new Map();
 
+  const updateCache = (key: Key, data: T) => {
+    const value: Updating<T> = {
+      status: 'UPDATING',
+      dataIsStale: true,
+      data,
+    };
+    cache = new Map([...cache, [key, value]]);
+  };
+
   return {
     useAll: (
       fetcher: () => Promise<Array<[Key, T]>>
@@ -76,17 +85,7 @@ export function cachedRemoteData<Key extends string, T>() {
 
       if (hasLoaded(values)) {
         values.data.forEach(([key, value]) => {
-          cache = new Map([
-            ...cache,
-            [
-              key,
-              {
-                status: 'UPDATING',
-                dataIsStale: true,
-                data: value,
-              },
-            ],
-          ]);
+          updateCache(key, value);
         });
 
         return new Map([
@@ -120,17 +119,7 @@ export function cachedRemoteData<Key extends string, T>() {
       }
 
       if (hasLoaded(value)) {
-        cache = new Map([
-          ...cache,
-          [
-            key,
-            {
-              status: 'UPDATING',
-              dataIsStale: true,
-              data: value.data,
-            },
-          ],
-        ]);
+        updateCache(key, value.data);
       }
 
       return value;

--- a/app/src/remote-data.ts
+++ b/app/src/remote-data.ts
@@ -77,7 +77,7 @@ export function cachedRemoteData<Key extends string, T>() {
           const message = values.userMessage;
           notify({
             type: 'ERROR',
-            title: 'All dataen kan ikkje lastes',
+            title: 'Ikke all dataen kunne lastes',
             message,
           });
         }

--- a/app/src/remote-data.ts
+++ b/app/src/remote-data.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { isError } from 'util';
+import { useNotification } from './components/NotificationHandler/NotificationHandler';
 
 export type Ok<T> = {
   status: 'OK';
@@ -59,7 +60,19 @@ export function cachedRemoteData<Key extends string, T>() {
     useAll: (
       fetcher: () => Promise<Array<[Key, T]>>
     ): Map<Key, RemoteData<T>> => {
+      const { notify } = useNotification();
       const values = useRemoteData(fetcher);
+
+      useEffect(() => {
+        if (isBad(values)) {
+          const message = values.userMessage;
+          notify({
+            type: 'ERROR',
+            title: 'All dataen kan ikkje lastes',
+            message,
+          });
+        }
+      }, [values, notify]);
 
       if (hasLoaded(values)) {
         values.data.forEach(([key, value]) => {

--- a/app/src/remote-data.ts
+++ b/app/src/remote-data.ts
@@ -12,8 +12,8 @@ export type Loading = {
   status: 'LOADING';
 };
 
-export type Pending<T> = {
-  status: 'PENDING';
+export type Updating<T> = {
+  status: 'UPDATING';
   dataIsStale: true;
   data: T;
 };
@@ -27,22 +27,22 @@ export type Bad = {
   userMessage: string;
 };
 
-export type RemoteData<T> = Ok<T> | Loading | Pending<T> | Bad | NotRequested;
+export type RemoteData<T> = Ok<T> | Loading | Updating<T> | Bad | NotRequested;
 
 export function isLoading<T>(data: RemoteData<T>): data is Loading {
   return data.status === 'LOADING';
 }
 
-export function isPending<T>(data: RemoteData<T>): data is Pending<T> {
-  return data.status === 'PENDING';
+export function isUpdating<T>(data: RemoteData<T>): data is Updating<T> {
+  return data.status === 'UPDATING';
 }
 
-export function isOk<T>(data: RemoteData<T>): data is Ok<T> {
+export function isFresh<T>(data: RemoteData<T>): data is Ok<T> {
   return data.status === 'OK';
 }
 
-export function hasLoaded<T>(data: RemoteData<T>): data is Ok<T> | Pending<T> {
-  return isOk(data) || isPending(data);
+export function hasLoaded<T>(data: RemoteData<T>): data is Ok<T> | Updating<T> {
+  return isFresh(data) || isUpdating(data);
 }
 
 export function isNotRequested<T>(data: RemoteData<T>): data is NotRequested {
@@ -76,7 +76,11 @@ export function cachedRemoteData<Key extends string, T>() {
 
       if (hasLoaded(values)) {
         values.data.forEach(([key, value]) => {
-          cache.set(key, { status: 'PENDING', dataIsStale: true, data: value });
+          cache.set(key, {
+            status: 'UPDATING',
+            dataIsStale: true,
+            data: value,
+          });
         });
 
         return new Map([
@@ -111,7 +115,7 @@ export function cachedRemoteData<Key extends string, T>() {
 
       if (hasLoaded(value)) {
         cache.set(key, {
-          status: 'PENDING',
+          status: 'UPDATING',
           dataIsStale: true,
           data: value.data,
         });
@@ -142,7 +146,7 @@ export const useUpdateRemoteData = <T, P>(
       setRemoteData(remoteData => {
         if (hasLoaded(remoteData)) {
           return {
-            status: 'PENDING',
+            status: 'UPDATING',
             dataIsStale: true,
             data: remoteData.data,
           };

--- a/app/src/remote-data.ts
+++ b/app/src/remote-data.ts
@@ -1,0 +1,94 @@
+import { useState, useEffect } from 'react';
+import { isError } from 'util';
+
+export type Ok<T> = {
+  status: 'OK';
+  data: T;
+};
+
+export type Loading = {
+  status: 'LOADING';
+};
+
+export type Pending<T> = {
+  status: 'PENDING';
+  staleData: T;
+};
+
+export type NotRequested = {
+  status: 'NOT_REQUESTED';
+};
+
+export type Bad = {
+  status: 'ERROR';
+  userMessage: string;
+};
+
+export type RemoteData<T> = Ok<T> | Loading | Pending<T> | Bad | NotRequested;
+
+export function isLoading<T>(data: RemoteData<T>): data is Loading {
+  return data.status === 'LOADING';
+}
+
+export function isPending<T>(data: RemoteData<T>): data is Pending<T> {
+  return data.status === 'PENDING';
+}
+
+export function isOk<T>(data: RemoteData<T>): data is Ok<T> {
+  return data.status === 'OK';
+}
+
+export function isNotRequested<T>(data: RemoteData<T>): data is NotRequested {
+  return data.status === 'NOT_REQUESTED';
+}
+
+export function isBad<T>(data: RemoteData<T>): data is Bad {
+  return data.status === 'ERROR';
+}
+
+export const useRemoteData = <T>(fetcher: () => Promise<T>): RemoteData<T> => {
+  const [remoteData, setRemoteData] = useState<RemoteData<T>>({
+    status: 'NOT_REQUESTED',
+  });
+
+  useEffect(() => {
+    setRemoteData({ status: 'LOADING' });
+    fetcher()
+      .then(data => setRemoteData({ status: 'OK', data }))
+      .catch(({ userMessage }) => {
+        return setRemoteData({
+          status: 'ERROR',
+          userMessage,
+        });
+      });
+  }, [fetcher]);
+
+  return remoteData;
+};
+
+export const useUpdateRemoteData = <T, P>(
+  fetcher: (param: P) => Promise<T>
+): [RemoteData<T>, (param: P) => void] => {
+  const [remoteData, setRemoteData] = useState<RemoteData<T>>({
+    status: 'NOT_REQUESTED',
+  });
+
+  const updateRemoteData = (param: P) => {
+    if (isOk(remoteData)) {
+      setRemoteData({ status: 'PENDING', staleData: remoteData.data });
+    }
+    if (isError(remoteData) || isNotRequested(remoteData)) {
+      setRemoteData({ status: 'LOADING' });
+    }
+    fetcher(param)
+      .then(data => setRemoteData({ status: 'OK', data }))
+      .catch(({ userMessage }) => {
+        return setRemoteData({
+          status: 'ERROR',
+          userMessage,
+        });
+      });
+  };
+
+  return [remoteData, updateRemoteData];
+};

--- a/app/src/remote-data.ts
+++ b/app/src/remote-data.ts
@@ -76,11 +76,17 @@ export function cachedRemoteData<Key extends string, T>() {
 
       if (hasLoaded(values)) {
         values.data.forEach(([key, value]) => {
-          cache.set(key, {
-            status: 'UPDATING',
-            dataIsStale: true,
-            data: value,
-          });
+          cache = new Map([
+            ...cache,
+            [
+              key,
+              {
+                status: 'UPDATING',
+                dataIsStale: true,
+                data: value,
+              },
+            ],
+          ]);
         });
 
         return new Map([
@@ -114,11 +120,17 @@ export function cachedRemoteData<Key extends string, T>() {
       }
 
       if (hasLoaded(value)) {
-        cache.set(key, {
-          status: 'UPDATING',
-          dataIsStale: true,
-          data: value.data,
-        });
+        cache = new Map([
+          ...cache,
+          [
+            key,
+            {
+              status: 'UPDATING',
+              dataIsStale: true,
+              data: value.data,
+            },
+          ],
+        ]);
       }
 
       return value;

--- a/app/src/types/event.ts
+++ b/app/src/types/event.ts
@@ -169,3 +169,17 @@ export const initialEvent: IEditEvent = {
   organizerEmail: parseEmail(''),
   maxParticipants: parseMaxAttendees(''),
 };
+
+export const maybeParseEvent = (eventContract: IEventContract): IEvent => {
+  const deserializedEvent = deserializeEvent(eventContract);
+  const domainEvent = parseEvent(deserializedEvent);
+  if (isOk(domainEvent)) {
+    return domainEvent.validValue;
+  }
+  throw {
+    status: 'ERROR',
+    userMessage:
+      'Arrangementobjektet kan ikke parses av følgende grunner: ' +
+      domainEvent.errors.map(x => x.message).join(', '),
+  };
+};

--- a/app/src/types/event.ts
+++ b/app/src/types/event.ts
@@ -176,6 +176,9 @@ export const maybeParseEvent = (eventContract: IEventContract): IEvent => {
   if (isOk(domainEvent)) {
     return domainEvent.validValue;
   }
+  // Man får egt bare lov å kaste new Error
+  // men det er tull
+  // eslint-disable-next-line
   throw {
     status: 'ERROR',
     userMessage:

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,11 +1,8 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "downlevelIteration": true,
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,7 +17,5 @@
     "jsx": "react",
     "baseUrl": "./"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.paths.json",
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
@@ -14,8 +15,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
-    "baseUrl": "./"
+    "jsx": "preserve"
   },
   "include": ["src"]
 }

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "./tsconfig.paths.json",
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "downlevelIteration": true,
     "allowJs": true,
     "skipLibCheck": true,
@@ -17,5 +21,7 @@
     "noEmit": true,
     "jsx": "preserve"
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }

--- a/app/tsconfig.paths.json
+++ b/app/tsconfig.paths.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "src/*": ["src/*"]
+    }
+  }
+}


### PR DESCRIPTION
### Denne endringa

Denne endringa introduserer remote data og ein "shared cache". I hovudsak har cachen som jobb å la deg gå mellom sidene i SPAen utan å møte på unødvendig loadingindikatorer. Den er shared slik at man kan vere på "rediger dette eventet", for så å manøvrere til "alle events": da vil "dette" eventet vere tilgjengelig øyeblikkelig i lista, mens vi venter på resten av eventsa som vil bli populert når nettverkskallet resolver.

Cachen oppdaterer heile tida seg sjølv, som betyr at der er eit kort vindu mellom sidebytt og ferdig innlasta data, kor man ser den cacha dataen. Denne er jo potensielt "stale", så difor introduserer også denne endringa her ein ny remote-data type "PENDING", som betyr at dataen er tilgjengelig, men også på veg. Her kan man velge om man vil behandle stale data som vanlig data, som sikkert er mesteparten av casene. I tillegg kan man teste på "isDataStale" dersom man vil vise dataen litt ut-gråa.

### Tekniske considerations

Cachen er implementert ved hjelp av ein Map. Denne datastrukturen er ganske smooth, fordi den respekterer insertion order. Dette betyr at vi ikkje mister rekkefølgen vi får dataen frå backenden i. I tillegg støtter den også andre keys enn strings, men det er ikkje noko vi har behov for med det første. For å iterere over Mapen må vi spreade den i ei liste, altså `[...minMap]`, men det er ei smal sak. Da får man `Key` og `Value` man kan iterere over.

En annen case er kva som skjer om man spør om ei lista av ting frå backenden, til dømes `getEvents()`. Desse eventene blir jo parse, som jo kan faile på nokon av eventsa, men ikkje alle. Da skulle det tenkes at man fikk tilbake ein Map der dei elementa som var fucked up var `isBad`. Men dette viste seg å komplisere ikkje bare caching og remote-data-koden, men også "klientkoden", så eg valgte å ikkje støtte det. Derfor thrower eg heller dersom eit slikt element blir funne, og heile den nye lista blir kasta. Cachen forblir likevel urørt, så tidligere lasta verdier forblir. I staden for blir feilmeldinga sendt til `catchAndNotify`-tingen, så brukeren får eit rødt banner som viser feilmeldinga.