### PR TITLE
:bug: Add correct format to openForRegistration on the preview-screen

### DIFF
--- a/app/src/components/PreviewEvent/PreviewEvent.tsx
+++ b/app/src/components/PreviewEvent/PreviewEvent.tsx
@@ -61,7 +61,7 @@ export const PreviewEvent = ({ event }: IProps) => {
       <DateInfo
         formatedDate={stringifyTimeInstanceDate(event.openForRegistrationTime)}
         formatedTime={stringifyTimeInstanceTime(event.openForRegistrationTime)}
-        label={'Starter'}
+        label={'Påmelding åpner'}
       />
       <Info text={event.maxParticipants.toString()} label={'Maks antall'} />
     </>

--- a/app/src/components/PreviewEvent/PreviewEvent.tsx
+++ b/app/src/components/PreviewEvent/PreviewEvent.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { IEvent } from 'src/types/event';
 import style from './PreviewEvent.module.scss';
-import { IDateTime } from 'src/types/date-time';
 import { stringifyTime } from 'src/types/time';
 import { stringifyDate } from 'src/types/date';
-import { stringifyTimeInstance } from 'src/types/time-instance';
+import {
+  stringifyTimeInstanceDate,
+  stringifyTimeInstanceTime,
+} from 'src/types/time-instance';
 import { stringifyEmail } from 'src/types/email';
 
 interface IProps {
@@ -12,11 +14,19 @@ interface IProps {
 }
 
 export const PreviewEvent = ({ event }: IProps) => {
-  const TimeInfo = ({ date, label }: { date: IDateTime; label: string }) => (
+  const DateInfo = ({
+    formatedDate,
+    formatedTime,
+    label,
+  }: {
+    formatedDate: string;
+    formatedTime: string;
+    label: string;
+  }) => (
     <div className={style.dataEntry}>
       <div className={style.labelText}>{label}</div>
-      <div>{stringifyDate(date.date)}</div>
-      <div>{stringifyTime(date.time)}</div>
+      <div>{formatedDate}</div>
+      <div>{formatedTime}</div>
     </div>
   );
 
@@ -38,11 +48,20 @@ export const PreviewEvent = ({ event }: IProps) => {
       />
       <Info text={event.location} label={'Lokasjon'} />
       <Info text={event.description} label={'Beskrivelse'} />
-      <TimeInfo date={event.start} label={'Starter'} />
-      <TimeInfo date={event.end} label={'Slutter'} />
-      <Info
-        label={'Påmeldingen åpner'}
-        text={stringifyTimeInstance(event.openForRegistrationTime)}
+      <DateInfo
+        formatedDate={stringifyDate(event.start.date)}
+        formatedTime={stringifyTime(event.start.time)}
+        label={'Starter'}
+      />
+      <DateInfo
+        formatedDate={stringifyDate(event.end.date)}
+        formatedTime={stringifyTime(event.end.time)}
+        label={'Starter'}
+      />
+      <DateInfo
+        formatedDate={stringifyTimeInstanceDate(event.openForRegistrationTime)}
+        formatedTime={stringifyTimeInstanceTime(event.openForRegistrationTime)}
+        label={'Starter'}
       />
       <Info text={event.maxParticipants.toString()} label={'Maks antall'} />
     </>

--- a/app/src/types/time-instance.ts
+++ b/app/src/types/time-instance.ts
@@ -82,5 +82,10 @@ export const serializeTimeInstance = (
   time: TimeInstance
 ): TimeInstanceContract => time.getTime().toString();
 
-export const stringifyTimeInstance = (date: TimeInstance): string =>
-  date.toLocaleDateString();
+export const stringifyTimeInstanceDate = (date: TimeInstance): string =>
+  `${twoDigitValue(date.getDay())}.${twoDigitValue(
+    date.getMonth() + 1
+  )}.${date.getFullYear()}`;
+
+export const stringifyTimeInstanceTime = (date: TimeInstance): string =>
+  `${twoDigitValue(date.getHours())}:${twoDigitValue(date.getMinutes())}`;


### PR DESCRIPTION
**Endring**
- La til `stringify`-metoder for dato og tid på `time-instance`
- Endret på komponenten `TimeInfo` (i `PreviewEvent.tsx`) til å heller ta inn to formaterte strenger (for dato og tid) så den kunne gjenbrukes for `TimeInstance`

![image](https://user-images.githubusercontent.com/42205202/75149522-7e601a80-5702-11ea-960c-2e8907ff6974.png)
