### PR TITLE
:bug: Validate date on blur instead of on change

### DIFF
--- a/app/src/components/Common/TimeInput/TimeInput.tsx
+++ b/app/src/components/Common/TimeInput/TimeInput.tsx
@@ -1,22 +1,29 @@
 import React, { useRef } from 'react';
 import { EditTime } from 'src/types/time';
 import style from './TimeInput.module.scss';
+import { useUpdateableInitialValue } from 'src/hooks/useInitialValue';
 
 interface IProps {
   value: EditTime;
   onChange: (value: EditTime) => void;
 }
 
-export const TimeInput = ({ value, onChange }: IProps) => {
-  const hour = value[0];
-  const minute = value[1];
+export const TimeInput = ({
+  value: [initialHour, initialMinute],
+  onChange,
+}: IProps) => {
+  const [hour, setHour] = useUpdateableInitialValue(initialHour);
+  const [minute, setMinute] = useUpdateableInitialValue(initialMinute);
 
-  const updateHour = (newHour: string) => {
-    onChange([newHour, minute]);
+  const changeHour = (newHour: string) => {
+    setHour(newHour);
+  };
+  const changeMinute = (newMinute: string) => {
+    setMinute(newMinute);
   };
 
-  const updateMinute = (newMinute: string) => {
-    onChange([hour, newMinute]);
+  const updateTime = () => {
+    onChange([hour, minute]);
   };
 
   const { focusMinuteRefWhenHourFull, minuteRef } = useHourMinuteFocus(hour);
@@ -31,7 +38,8 @@ export const TimeInput = ({ value, onChange }: IProps) => {
         className={style.timeInput}
         type="number"
         value={hour}
-        onChange={v => updateHour(v.target.value)}
+        onChange={v => changeHour(v.target.value)}
+        onBlur={updateTime}
         onKeyDown={focusMinuteRefWhenHourFull}
         onFocus={selectText}
       />
@@ -40,8 +48,9 @@ export const TimeInput = ({ value, onChange }: IProps) => {
         className={style.timeInput}
         ref={minuteRef}
         type="number"
+        onBlur={updateTime}
         value={minute}
-        onChange={v => updateMinute(v.target.value)}
+        onChange={v => changeMinute(v.target.value)}
         onFocus={selectText}
       />
     </div>

--- a/app/src/components/Common/TimeInput/TimeInput.tsx
+++ b/app/src/components/Common/TimeInput/TimeInput.tsx
@@ -15,13 +15,6 @@ export const TimeInput = ({
   const [hour, setHour] = useUpdateableInitialValue(initialHour);
   const [minute, setMinute] = useUpdateableInitialValue(initialMinute);
 
-  const changeHour = (newHour: string) => {
-    setHour(newHour);
-  };
-  const changeMinute = (newMinute: string) => {
-    setMinute(newMinute);
-  };
-
   const updateTime = () => {
     onChange([hour, minute]);
   };
@@ -38,7 +31,7 @@ export const TimeInput = ({
         className={style.timeInput}
         type="number"
         value={hour}
-        onChange={v => changeHour(v.target.value)}
+        onChange={v => setHour(v.target.value)}
         onBlur={updateTime}
         onKeyDown={focusMinuteRefWhenHourFull}
         onFocus={selectText}
@@ -50,7 +43,7 @@ export const TimeInput = ({
         type="number"
         onBlur={updateTime}
         value={minute}
-        onChange={v => changeMinute(v.target.value)}
+        onChange={v => setMinute(v.target.value)}
         onFocus={selectText}
       />
     </div>

--- a/app/src/hooks/useInitialValue.ts
+++ b/app/src/hooks/useInitialValue.ts
@@ -1,6 +1,8 @@
 import { useState, useLayoutEffect } from 'react';
 
-export const useUpdateableInitialValue = (initialValue: any) => {
+export const useUpdateableInitialValue = <T extends string | number>(
+  initialValue: T
+): [T, (value: T) => void] => {
   const [value, setValue] = useState(initialValue);
   useLayoutEffect(() => {
     setValue(initialValue);

--- a/app/src/hooks/useInitialValue.ts
+++ b/app/src/hooks/useInitialValue.ts
@@ -1,0 +1,10 @@
+import { useState, useLayoutEffect } from 'react';
+
+export const useUpdateableInitialValue = (initialValue: any) => {
+  const [value, setValue] = useState(initialValue);
+  useLayoutEffect(() => {
+    setValue(initialValue);
+  }, [initialValue]);
+
+  return [value, setValue];
+};


### PR DESCRIPTION
**Endring**
Endret litt på logikken i `TimeInput` så klokkeslettet lever i lokal state, og kjører oppdatering (og validering) når den mister fokus.

**Ting jeg lurer litt på**
- `useInitialValue` er ikke et veldig bra navn, men kom ikke på noe bedre.. Har du forslag til noe bedre? :)
- for å lage `useInitialValue` generisk ville jeg egentlig kjøre `initialValue` som type `string | number`. Men da ble det mye hat.. Jeg satte den til `: any`. Kan dette løses på noen bedre måte?