### PR TITLE
Bug fixes before release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ node_modules
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.vscode/settings.json

--- a/app/src/api/arrangementSvc.ts
+++ b/app/src/api/arrangementSvc.ts
@@ -61,11 +61,31 @@ export const deleteEvent = (
   });
 
 export const getParticipantsForEvent = (
-  eventId: string
+  eventId: string,
+  editToken?: string
 ): Promise<IParticipantViewModelsWithWaitingList> =>
   get({
     host: getArrangementSvcUrl(),
-    path: `/events/${eventId}/participants`,
+    path: `/events/${eventId}/participants${queryStringStringify({
+      editToken,
+    })}`,
+  });
+
+export const getNumberOfParticipantsForEvent = (
+  eventId: string
+): Promise<number> =>
+  get({
+    host: getArrangementSvcUrl(),
+    path: `/events/${eventId}/participants/count`,
+  });
+
+export const getWaitinglistSpot = (
+  eventId: string,
+  email: string
+): Promise<number> =>
+  get({
+    host: getArrangementSvcUrl(),
+    path: `/events/${eventId}/participants/${email}/waitinglist-spot`,
   });
 
 export const postParticipant = (

--- a/app/src/components/ConfirmParticipant/ConfirmParticipant.tsx
+++ b/app/src/components/ConfirmParticipant/ConfirmParticipant.tsx
@@ -13,19 +13,19 @@ export const ConfirmParticipant = () => {
   const participantEmail = useParam(emailKey);
 
   const remoteEvent = useEvent(eventId);
-  const remoteWaitinglistspot = useWaitinglistSpot(eventId, participantEmail);
+  const remoteWaitinglistSpot = useWaitinglistSpot(eventId, participantEmail);
 
-  if (!hasLoaded(remoteEvent) || !hasLoaded(remoteWaitinglistspot)) {
+  if (!hasLoaded(remoteEvent) || !hasLoaded(remoteWaitinglistSpot)) {
     return <div>Loading...</div>;
   }
 
   const event = remoteEvent.data;
-  const isWaitlisted = remoteWaitinglistspot.data >= 1;
+  const isWaitlisted = remoteWaitinglistSpot.data >= 1;
 
   return isWaitlisted ? (
     <Page>
       <h1 className={style.header}>
-        Du er nummer {remoteWaitinglistspot.data} på ventelisten!
+        Du er nummer {remoteWaitinglistSpot.data} på ventelisten!
       </h1>
       <div className={style.text}>
         Du er nå på venteliste for {event.title} den{' '}

--- a/app/src/components/ConfirmParticipant/ConfirmParticipant.tsx
+++ b/app/src/components/ConfirmParticipant/ConfirmParticipant.tsx
@@ -6,31 +6,27 @@ import { viewEventRoute, eventIdKey, emailKey } from 'src/routing';
 import { hasLoaded } from 'src/remote-data';
 import { BlockLink } from 'src/components/Common/BlockLink/BlockLink';
 import { useParam } from 'src/utils/browser-state';
-import { useEvent, useParticipants } from 'src/hooks/cache';
+import { useEvent, useWaitinglistSpot } from 'src/hooks/cache';
 import { Page } from 'src/components/Page/Page';
-import { stringifyEmail } from 'src/types/email';
-
 export const ConfirmParticipant = () => {
   const eventId = useParam(eventIdKey);
   const participantEmail = useParam(emailKey);
 
   const remoteEvent = useEvent(eventId);
-  const remoteParticipants = useParticipants(eventId);
+  const remoteWaitinglistspot = useWaitinglistSpot(eventId, participantEmail);
 
-  if (!hasLoaded(remoteEvent) || !hasLoaded(remoteParticipants)) {
+  if (!hasLoaded(remoteEvent) || !hasLoaded(remoteWaitinglistspot)) {
     return <div>Loading...</div>;
   }
 
   const event = remoteEvent.data;
-  const attendees = remoteParticipants.data.attendees;
-
-  const isWaitlisted =
-    event.hasWaitingList &&
-    !attendees.some(p => stringifyEmail(p.email) === participantEmail);
+  const isWaitlisted = remoteWaitinglistspot.data >= 1;
 
   return isWaitlisted ? (
     <Page>
-      <h1 className={style.header}>Du er på ventelisten!</h1>
+      <h1 className={style.header}>
+        Du er nummer {remoteWaitinglistspot.data} på ventelisten!
+      </h1>
       <div className={style.text}>
         Du er nå på venteliste for {event.title} den{' '}
         {stringifyDate(event.start.date)} kl {stringifyTime(event.start.time)} -{' '}

--- a/app/src/components/PreviewEvent/PreviewEventContainer.tsx
+++ b/app/src/components/PreviewEvent/PreviewEventContainer.tsx
@@ -22,7 +22,7 @@ export const PreviewEventContainer = () => {
   }
 
   const participantsText = `0 av ${event.maxParticipants === 0 ? '∞' : event.maxParticipants}${
-    event.hasWaitingList && event.maxParticipants != 0 ? ' og 0 på venteliste' : ''
+    event.hasWaitingList && event.maxParticipants !== 0 ? ' og 0 på venteliste' : ''
   }`;
 
   const putEditedEvent = catchAndNotify(async () => {

--- a/app/src/components/PreviewEvent/PreviewEventContainer.tsx
+++ b/app/src/components/PreviewEvent/PreviewEventContainer.tsx
@@ -21,8 +21,8 @@ export const PreviewEventContainer = () => {
     return <div>Det finnes ingen event å forhåndsvise</div>;
   }
 
-  const participantsText = `0 av ${event.maxParticipants ?? '∞'}${
-    event.hasWaitingList ? ' og 0 på venteliste' : ''
+  const participantsText = `0 av ${event.maxParticipants === 0 ? '∞' : event.maxParticipants}${
+    event.hasWaitingList && event.maxParticipants != 0 ? ' og 0 på venteliste' : ''
   }`;
 
   const putEditedEvent = catchAndNotify(async () => {

--- a/app/src/components/PreviewEvent/PreviewNewEventContainer.tsx
+++ b/app/src/components/PreviewEvent/PreviewNewEventContainer.tsx
@@ -21,8 +21,8 @@ export const PreviewNewEventContainer = () => {
     return <div>Det finnes ingen event å forhåndsvise</div>;
   }
 
-  const participantsText = `0 av ${event.maxParticipants ?? '∞'}${
-    event.hasWaitingList ? ' og 0 på venteliste' : ''
+  const participantsText = `0 av ${event.maxParticipants === 0 ? '∞' : event.maxParticipants}${
+    event.hasWaitingList && event.maxParticipants != 0 ? ' og 0 på venteliste' : ''
   }`;
 
   const postNewEvent = catchAndNotify(async () => {

--- a/app/src/components/PreviewEvent/PreviewNewEventContainer.tsx
+++ b/app/src/components/PreviewEvent/PreviewNewEventContainer.tsx
@@ -22,7 +22,7 @@ export const PreviewNewEventContainer = () => {
   }
 
   const participantsText = `0 av ${event.maxParticipants === 0 ? '∞' : event.maxParticipants}${
-    event.hasWaitingList && event.maxParticipants != 0 ? ' og 0 på venteliste' : ''
+    event.hasWaitingList && event.maxParticipants !== 0 ? ' og 0 på venteliste' : ''
   }`;
 
   const postNewEvent = catchAndNotify(async () => {

--- a/app/src/components/ViewEvent/AddParticipant.tsx
+++ b/app/src/components/ViewEvent/AddParticipant.tsx
@@ -21,10 +21,9 @@ import { useSavedParticipations } from 'src/hooks/saved-tokens';
 interface Props {
   eventId: string;
   event: IEvent;
-  isWaitlisted: boolean;
 }
 
-export const AddParticipant = ({ eventId, event, isWaitlisted }: Props) => {
+export const AddParticipant = ({ eventId, event }: Props) => {
   const { catchAndNotify } = useNotification();
   const history = useHistory();
 

--- a/app/src/components/ViewEvent/AddParticipant.tsx
+++ b/app/src/components/ViewEvent/AddParticipant.tsx
@@ -24,7 +24,7 @@ interface Props {
   isWaitlisted: boolean;
 }
 
-export const EditParticipation = ({ eventId, event, isWaitlisted }: Props) => {
+export const AddParticipant = ({ eventId, event, isWaitlisted }: Props) => {
   const { catchAndNotify } = useNotification();
   const history = useHistory();
 

--- a/app/src/components/ViewEvent/ViewEventContainer.tsx
+++ b/app/src/components/ViewEvent/ViewEventContainer.tsx
@@ -118,7 +118,6 @@ export const ViewEventContainer = () => {
           <AddParticipant
             eventId={eventId}
             event={event}
-            isWaitlisted={eventIsFull && event.hasWaitingList}
           />
         )}
         {(editTokenFound || userIsAdmin()) && (

--- a/app/src/components/ViewEvent/ViewEventContainer.tsx
+++ b/app/src/components/ViewEvent/ViewEventContainer.tsx
@@ -9,34 +9,36 @@ import {
   editEventRoute,
   eventIdKey,
 } from 'src/routing';
-import { stringifyEmail } from 'src/types/email';
 import { userIsLoggedIn, userIsAdmin } from 'src/auth';
 import { hasLoaded, isBad } from 'src/remote-data';
 import { Page } from 'src/components/Page/Page';
 import { BlockLink } from 'src/components/Common/BlockLink/BlockLink';
 import { ViewEvent } from 'src/components/ViewEvent/ViewEvent';
 import { useParam } from 'src/utils/browser-state';
-import { useEvent, useParticipants } from 'src/hooks/cache';
+import { useEvent, useNumberOfParticipants } from 'src/hooks/cache';
 import {
   useSavedEditableEvents,
   useSavedParticipations,
 } from 'src/hooks/saved-tokens';
-import { EditParticipation } from 'src/components/ViewEvent/EditParticipation';
+import { AddParticipant } from 'src/components/ViewEvent/AddParticipant';
+import { ViewParticipants } from 'src/components/ViewEvent/ViewParticipants';
 
 export const ViewEventContainer = () => {
   const eventId = useParam(eventIdKey);
   const remoteEvent = useEvent(eventId);
 
-  const remoteParticipants = useParticipants(eventId);
-
   const { savedEvents } = useSavedEditableEvents();
-  const editTokenFound = savedEvents.find(event => event.eventId === eventId);
+  const editTokenFound = savedEvents.find((event) => event.eventId === eventId);
 
-  const {
-    savedParticipations: participationsInLocalStorage,
-  } = useSavedParticipations();
+  const remoteNumberOfParticipants = useNumberOfParticipants(eventId);
+  const numberOfParticipants = hasLoaded(remoteNumberOfParticipants)
+    ? remoteNumberOfParticipants.data
+    : '-';
+
+  const { savedParticipations: participationsInLocalStorage } =
+    useSavedParticipations();
   const participationsForThisEvent = participationsInLocalStorage.filter(
-    p => p.eventId === eventId
+    (p) => p.eventId === eventId
   );
 
   const timeLeft = useTimeLeft(
@@ -52,23 +54,25 @@ export const ViewEventContainer = () => {
   }
 
   const event = remoteEvent.data;
-  const attendees = hasLoaded(remoteParticipants)
-    ? remoteParticipants.data.attendees
-    : [];
-  const waitingList = hasLoaded(remoteParticipants)
-    ? remoteParticipants.data.waitingList
-    : [];
 
   const eventIsFull =
-    event.maxParticipants !== 0 && event.maxParticipants === attendees.length;
+    event.maxParticipants !== 0 &&
+    event.maxParticipants <= numberOfParticipants;
 
-  const participantsText = `${attendees.length}${
+  const waitingList =
+    hasLoaded(remoteNumberOfParticipants) && eventIsFull
+      ? remoteNumberOfParticipants.data - event.maxParticipants
+      : '-';
+
+  const participantsText = `${
+    eventIsFull ? event.maxParticipants : numberOfParticipants
+  }${
     event.maxParticipants === 0
       ? ' av ∞'
       : ' av ' +
         event.maxParticipants +
-        (waitingList && eventIsFull
-          ? ` og ${waitingList.length} på venteliste`
+        (event.hasWaitingList && eventIsFull
+          ? ` og ${waitingList} på venteliste`
           : '')
   }`;
 
@@ -76,7 +80,7 @@ export const ViewEventContainer = () => {
     ? 'Arrangementet har allerede funnet sted'
     : timeLeft.difference > 0
     ? `Åpner om ${asString(timeLeft)}`
-    : eventIsFull && !waitingList
+    : eventIsFull && !event.hasWaitingList
     ? 'Arrangementet er dessverre fullt'
     : undefined;
 
@@ -95,7 +99,7 @@ export const ViewEventContainer = () => {
           Rediger arrangement
         </BlockLink>
       )}
-      {participationsForThisEvent.map(p => (
+      {participationsForThisEvent.map((p) => (
         <BlockLink key={p.email} to={cancelParticipantRoute(p)}>
           Meld {p.email} av arrangementet
         </BlockLink>
@@ -111,44 +115,18 @@ export const ViewEventContainer = () => {
           <p className={style.text}>{waitlistText}</p>
         ) : null}
         {!closedEventText && (
-          <EditParticipation
+          <AddParticipant
             eventId={eventId}
             event={event}
             isWaitlisted={eventIsFull && event.hasWaitingList}
           />
         )}
-        <h1 className={style.subHeader}>Påmeldte</h1>
-        <div>
-          {attendees.length > 0 ? (
-            attendees.map(attendee => {
-              return (
-                <div
-                  key={stringifyEmail(attendee.email)}
-                  className={style.text}
-                >
-                  {attendee.name}, {stringifyEmail(attendee.email)}, Kommentar:{' '}
-                  {attendee.comment}
-                </div>
-              );
-            })
-          ) : (
-            <div className={style.text}>Ingen påmeldte</div>
-          )}
-          {waitingList && waitingList.length > 0 && (
-            <>
-              <h3>På venteliste</h3>
-              {waitingList.map(waitlisted => (
-                <div
-                  key={stringifyEmail(waitlisted.email)}
-                  className={style.text}
-                >
-                  {waitlisted.name}, {stringifyEmail(waitlisted.email)},
-                  Kommentar: {waitlisted.comment}
-                </div>
-              ))}
-            </>
-          )}
-        </div>
+        {(editTokenFound || userIsAdmin()) && (
+          <ViewParticipants
+            eventId={eventId}
+            editToken={editTokenFound?.editToken}
+          />
+        )}
       </section>
     </Page>
   );

--- a/app/src/components/ViewEvent/ViewParticipants.tsx
+++ b/app/src/components/ViewEvent/ViewParticipants.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import style from './ViewEventContainer.module.scss';
+import { stringifyEmail } from 'src/types/email';
+import { useParticipants } from 'src/hooks/cache';
+import { hasLoaded } from 'src/remote-data';
+
+interface IProps {
+  eventId: string;
+  editToken?: string;
+}
+
+export const ViewParticipants = ({ eventId, editToken }: IProps) => {
+  const remoteParticipants = useParticipants(eventId, editToken);
+
+  const attendees = hasLoaded(remoteParticipants)
+    ? remoteParticipants.data.attendees
+    : [];
+  const waitingList = hasLoaded(remoteParticipants)
+    ? remoteParticipants.data.waitingList
+    : [];
+
+  return (
+    <div>
+      <h1 className={style.subHeader}>Påmeldte</h1>
+      <div>
+        {attendees.length > 0 ? (
+          attendees.map((attendee) => {
+            return (
+              <div key={stringifyEmail(attendee.email)} className={style.text}>
+                {attendee.name}, {stringifyEmail(attendee.email)}, Kommentar:{' '}
+                {attendee.comment}
+              </div>
+            );
+          })
+        ) : (
+          <div className={style.text}>Ingen påmeldte</div>
+        )}
+        {waitingList && waitingList.length > 0 && (
+          <>
+            <h3>På venteliste</h3>
+            {waitingList.map((waitlisted) => (
+              <div
+                key={stringifyEmail(waitlisted.email)}
+                className={style.text}
+              >
+                {waitlisted.name}, {stringifyEmail(waitlisted.email)},
+                Kommentar: {waitlisted.comment}
+              </div>
+            ))}
+          </>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/app/src/components/ViewEvent/ViewParticipants.tsx
+++ b/app/src/components/ViewEvent/ViewParticipants.tsx
@@ -12,19 +12,16 @@ interface IProps {
 export const ViewParticipants = ({ eventId, editToken }: IProps) => {
   const remoteParticipants = useParticipants(eventId, editToken);
 
-  const attendees = hasLoaded(remoteParticipants)
-    ? remoteParticipants.data.attendees
-    : [];
-  const waitingList = hasLoaded(remoteParticipants)
-    ? remoteParticipants.data.waitingList
-    : [];
+  if (!hasLoaded(remoteParticipants)) {
+    return <div>Laster...</div>;
+  }
 
   return (
     <div>
       <h1 className={style.subHeader}>Påmeldte</h1>
       <div>
-        {attendees.length > 0 ? (
-          attendees.map((attendee) => {
+        {remoteParticipants.data.attendees.length > 0 ? (
+          remoteParticipants.data.attendees.map((attendee) => {
             return (
               <div key={stringifyEmail(attendee.email)} className={style.text}>
                 {attendee.name}, {stringifyEmail(attendee.email)}, Kommentar:{' '}
@@ -35,10 +32,10 @@ export const ViewParticipants = ({ eventId, editToken }: IProps) => {
         ) : (
           <div className={style.text}>Ingen påmeldte</div>
         )}
-        {waitingList && waitingList.length > 0 && (
+        {remoteParticipants.data.waitingList && remoteParticipants.data.waitingList.length > 0 && (
           <>
             <h3>På venteliste</h3>
-            {waitingList.map((waitlisted) => (
+            {remoteParticipants.data.waitingList.map((waitlisted) => (
               <div
                 key={stringifyEmail(waitlisted.email)}
                 className={style.text}

--- a/app/src/components/ViewEvents/EventListElement.tsx
+++ b/app/src/components/ViewEvents/EventListElement.tsx
@@ -7,7 +7,7 @@ import { stringifyTime } from 'src/types/time';
 import { viewEventRoute, editEventRoute } from 'src/routing';
 import { userIsAdmin } from 'src/auth';
 import { hasLoaded } from 'src/remote-data';
-import { useNumberOfParticipants, useParticipants } from 'src/hooks/cache';
+import { useNumberOfParticipants } from 'src/hooks/cache';
 import { useSavedEditableEvents } from 'src/hooks/saved-tokens';
 
 interface IProps {

--- a/app/src/components/ViewEvents/EventListElement.tsx
+++ b/app/src/components/ViewEvents/EventListElement.tsx
@@ -7,7 +7,7 @@ import { stringifyTime } from 'src/types/time';
 import { viewEventRoute, editEventRoute } from 'src/routing';
 import { userIsAdmin } from 'src/auth';
 import { hasLoaded } from 'src/remote-data';
-import { useParticipants } from 'src/hooks/cache';
+import { useNumberOfParticipants, useParticipants } from 'src/hooks/cache';
 import { useSavedEditableEvents } from 'src/hooks/saved-tokens';
 
 interface IProps {
@@ -16,11 +16,11 @@ interface IProps {
 }
 
 export const EventListElement = ({ eventId, event }: IProps) => {
-  const remoteParticipants = useParticipants(eventId);
-  const attendees = hasLoaded(remoteParticipants)
-    ? remoteParticipants.data.attendees
-    : [];
-  const participantsCount = attendees.length;
+  const remoteNumberOfParticipants = useNumberOfParticipants(eventId);
+  const numberOfParticipants = hasLoaded(remoteNumberOfParticipants)
+    ? remoteNumberOfParticipants.data
+    : '-';
+
   const participantLimitText =
     event.maxParticipants === 0 ? '' : ` av ${event.maxParticipants}`;
   const dateText = isSameDate(event.start.date, event.end.date)
@@ -33,7 +33,7 @@ export const EventListElement = ({ eventId, event }: IProps) => {
   )}`;
 
   const { savedEvents: createdEvents } = useSavedEditableEvents();
-  const createdThisEvent = createdEvents.find(x => x.eventId === eventId);
+  const createdThisEvent = createdEvents.find((x) => x.eventId === eventId);
 
   const viewRoute = viewEventRoute(eventId);
   const editRoute =
@@ -48,7 +48,7 @@ export const EventListElement = ({ eventId, event }: IProps) => {
         <div className={style.date}>{dateText}</div>
         <div className={style.desktopDate}> {desktopTimeText}</div>
         <div className={style.desktopText}>
-          {participantsCount}
+          {numberOfParticipants}
           {participantLimitText} påmeldte
         </div>
         <div className={style.desktopText}>

--- a/app/src/hooks/cache.ts
+++ b/app/src/hooks/cache.ts
@@ -56,7 +56,7 @@ export const useParticipants = (eventId: string, editToken?: string) => {
         attendees: attendees.map(parseParticipantViewModel),
         waitingList: waitingList?.map(parseParticipantViewModel),
       };
-    }, [eventId]),
+    }, [eventId, editToken]),
   });
 };
 

--- a/app/src/hooks/cache.ts
+++ b/app/src/hooks/cache.ts
@@ -4,7 +4,9 @@ import { useCallback } from 'react';
 import {
   getEvent,
   getEvents,
+  getNumberOfParticipantsForEvent,
   getParticipantsForEvent,
+  getWaitinglistSpot,
 } from 'src/api/arrangementSvc';
 import {
   IParticipantViewModel,
@@ -39,20 +41,47 @@ export const useEvents = () => {
 
 //**  Participant  **//
 
-const participantsCache = cachedRemoteData<
-  string,
-  IParticipantsWithWaitingList
->();
+const participantsCache =
+  cachedRemoteData<string, IParticipantsWithWaitingList>();
 
-export const useParticipants = (eventId: string) => {
+export const useParticipants = (eventId: string, editToken?: string) => {
   return participantsCache.useOne({
     key: eventId,
     fetcher: useCallback(async () => {
-      const { attendees, waitingList } = await getParticipantsForEvent(eventId);
+      const { attendees, waitingList } = await getParticipantsForEvent(
+        eventId,
+        editToken
+      );
       return {
         attendees: attendees.map(parseParticipantViewModel),
         waitingList: waitingList?.map(parseParticipantViewModel),
       };
     }, [eventId]),
+  });
+};
+
+const numberOfParticipantsCache = cachedRemoteData<string, number>();
+
+export const useNumberOfParticipants = (eventId: string) => {
+  return numberOfParticipantsCache.useOne({
+    key: eventId,
+    fetcher: useCallback(async () => {
+      const numberOfParticipants = await getNumberOfParticipantsForEvent(
+        eventId
+      );
+      return numberOfParticipants;
+    }, [eventId]),
+  });
+};
+
+const waitinglistSpotCache = cachedRemoteData<string, number>();
+
+export const useWaitinglistSpot = (eventId: string, email: string) => {
+  return waitinglistSpotCache.useOne({
+    key: `${eventId}:${email}`,
+    fetcher: useCallback(async () => {
+      const waitinglistSpot = await getWaitinglistSpot(eventId, email);
+      return waitinglistSpot;
+    }, [eventId, email]),
   });
 };


### PR DESCRIPTION
**Mål:** 
Begrense visning av deltakere på et arrangement til admins og de som har edit token til arrangementet. Resterende kalles videre for "vanlige brukere".  

https://trello.com/c/XqKiY0On/998-sjekk-at-liste-over-p%C3%A5meldte-bare-er-tilgjengelig-for-arrang%C3%B8r

**Endringer:**
🧚🏻‍♀️ Generelt benyttes det nå et nytt endepunkt for å hente antall deltakere istedenfor å hente en liste med informasjon om alle deltakerne. Dette benyttes alle steder hvor antall deltakere skal vises for "vanlige brukere". Dette gjør at det er mye endring fra useParticipants til useNumberOfParticipants. Dette brukes på: 
- Forsiden (oversikten over alle arrangementer)
- Infosiden til et arrangement 

🧚🏻‍♀️ Listen over deltakere med informasjon vises kun til de som har edit-token og admins. 

🧚🏻‍♀️ Listen over deltakere er lagt i en egen komponent "ViewParticipants". 

🧚🏻‍♀️ Når man melder seg på et arrangement får man beskjed om hvilken plass man har på ventelisten dersom det ikke er plass på arrangementet. 

🧚🏻‍♀️EditParticipant har endret navn til AddParticipant fordi den brukes til å registrere en deltaker og det er ikke mulig å redigere i denne viewen. 

🧚🏻‍♀️ Endring i forhåndsvisning etter redigering av arrangement for å håndtere ubegrenset påmelding