### PR TITLE
Customized modals for mobile screen size

### DIFF
--- a/app/src/components/Common/ButtonWithConfirmModal/ButtonWith.module.scss
+++ b/app/src/components/Common/ButtonWithConfirmModal/ButtonWith.module.scss
@@ -7,4 +7,12 @@
   outline: 0;
   padding: 10px;
   resize: vertical;
+  width: 100%;
+}
+
+.groupedButtons {
+  display: flex;
+  justify-content: space-between;
+  align-content: center;
+  margin-top: 10px;
 }

--- a/app/src/components/Common/ButtonWithConfirmModal/ButtonWithPromptModal.tsx
+++ b/app/src/components/Common/ButtonWithConfirmModal/ButtonWithPromptModal.tsx
@@ -10,9 +10,16 @@ interface IProps {
   onConfirm: (promptAnswer: string) => void;
   children: ReactChild | ReactChild[];
   placeholder?: string;
+  textareaLabel?: string;
 }
 
-export function ButtonWithPromptModal({ text, onConfirm, placeholder, children }: IProps) {
+export function ButtonWithPromptModal({
+  text,
+  onConfirm,
+  placeholder,
+  children,
+  textareaLabel,
+}: IProps) {
   const [showModal, setShowModal] = useState(false);
   const [promptAnswer, setPromptAnswer] = useState('');
   const confirmAndClose = () => {
@@ -26,16 +33,24 @@ export function ButtonWithPromptModal({ text, onConfirm, placeholder, children }
         <Modal header={text} closeModal={() => setShowModal(false)}>
           <>
             {children}
-            <TextareaAutosize
-              className={style.textArea}
-              placeholder={placeholder}
-              value={promptAnswer}
-              onChange={event => setPromptAnswer(event.target.value)}
-              minRows={5}
-            />
-            <Button color={'White'} onClick={confirmAndClose}>
-              {text}
-            </Button>
+            <div>
+              <p>{textareaLabel}</p>
+              <TextareaAutosize
+                className={style.textArea}
+                placeholder={placeholder}
+                value={promptAnswer}
+                onChange={(event) => setPromptAnswer(event.target.value)}
+                minRows={5}
+              />
+            </div>
+            <div className={style.groupedButtons}>
+              <Button color={'White'} onClick={confirmAndClose}>
+                {text}
+              </Button>
+              <Button color={'Black'} onClick={() => setShowModal(false)}>
+                Avbryt
+              </Button>
+            </div>
           </>
         </Modal>
       )}

--- a/app/src/components/Common/Modal/Modal.module.scss
+++ b/app/src/components/Common/Modal/Modal.module.scss
@@ -9,9 +9,12 @@
   left: 0;
   top: 0;
   width: 100vw;
+  max-height: 100vh;
   min-height: 100vh;
-  background: rgba(0, 0, 0, 0.5);
   z-index: 3;
+  @media #{$desktop} {
+    background: rgba(0, 0, 0, 0.5);
+  }
 }
 
 .modal {
@@ -27,18 +30,28 @@
   min-width: $modalWidth;
   min-height: $modalHeight;
   max-width: 95vw;
+  @media #{$mobile} {
+    min-width: 100vw;
+    max-width: 100vh;
+    min-height: 100vh;
+    max-height: 100vh;
+  }
 }
 
 .header {
-  @include boldText;
+  @include headerText;
   color: var(--backgroundColor);
   height: $modalPadding;
+  line-height: 50px;
   padding-left: $modalPadding;
   margin-bottom: 20px;
   max-width: 600px;
 }
 
 .modalContent {
+  @include regularText;
+  color: var(--svart);
+  line-height: 25px;
   padding: $modalPadding;
   padding-top: 0;
   display: flex;

--- a/app/src/components/EditEvent/EditEventContainer.module.scss
+++ b/app/src/components/EditEvent/EditEventContainer.module.scss
@@ -21,6 +21,6 @@
   margin-top: 10px;
 }
 
-.groupedButtons > :not(:first-child) {
+.groupedButtons > button:not(:first-child) {
   margin-left: 10px;
 }

--- a/app/src/components/EditEvent/EditEventContainer.tsx
+++ b/app/src/components/EditEvent/EditEventContainer.tsx
@@ -87,17 +87,15 @@ export const EditEventContainer = () => {
             text={'Avlys arrangement'}
             onConfirm={onDeleteEvent}
             placeholder="Arrangementet er avlyst pga. ..."
+            textareaLabel="Send en forklarende tekst på e-post til alle påmeldte deltakere:"
           >
             <>
               <p>
                 Er du sikker på at du vil avlyse arrangementet? <br />
-                Alle deltakere vil bli slettet. Dette kan ikke reverseres {' '}
+                Alle deltakere vil bli slettet. Dette kan ikke reverseres{' '}
                 <span role="img" aria-label="grimacing-face">
                   😬
                 </span>
-              </p>
-              <p>
-                Send en forklarende tekst på e-post til alle påmeldte deltakere:
               </p>
             </>
           </ButtonWithPromptModal>

--- a/app/src/style/constants.scss
+++ b/app/src/style/constants.scss
@@ -8,7 +8,7 @@ $tabletMaxWidth: 1024px;
 $desktopMinWidth: 1025px;
 
 $headerDesktop: 50px;
-$headerMobile: 30px;
+$headerMobile: 35px;
 $subHeaderDesktop: 37px;
 $subHeaderMobile: 25px;
 $textDesktop: 20px;
@@ -18,6 +18,7 @@ $smallMobile: 12px;
 $buttonMobile: 16px;
 
 $desktop: 'only screen and (min-width: #{$desktopMinWidth})';
+$mobile: 'screen and (max-width: #{$mobileMaxWidth})';
 
 $modalWidth: 600px;
 $modalHeight: 350px;


### PR DESCRIPTION
Tilpasset modaler til mobil og lagt inn en avbryt-knapp slik at man kan lukke Modalen uten å trykke utenfor rammen. Endringene består for det meste av styling/CSS og litt nye klassenavn. 

Modelene dekker nå hele skjermen dersom man er på mobil, eller har nettleseren veldig smal. På tablet og pc vil modalene fungere som før. 