### PR TITLE
Feedback changes

### DIFF
--- a/app/src/components/PreviewEvent/PreviewEventContainer.module.scss
+++ b/app/src/components/PreviewEvent/PreviewEventContainer.module.scss
@@ -13,4 +13,6 @@
 
 .buttonContainer {
   margin-top: 30px;
+  display: flex;
+  justify-content: space-between;
 }

--- a/app/src/components/PreviewEvent/PreviewEventContainer.tsx
+++ b/app/src/components/PreviewEvent/PreviewEventContainer.tsx
@@ -4,11 +4,15 @@ import { Page } from 'src/components/Page/Page';
 import { useNotification } from 'src/components/NotificationHandler/NotificationHandler';
 import { useHistory } from 'react-router';
 import { useParam } from 'src/utils/browser-state';
-import { eventIdKey, viewEventRoute } from 'src/routing';
+import { editEventRoute, eventIdKey, viewEventRoute } from 'src/routing';
 import { putEvent } from 'src/api/arrangementSvc';
 import { ViewEvent } from 'src/components/ViewEvent/ViewEvent';
 import { Button } from 'src/components/Common/Button/Button';
-import { usePreviewEvent } from 'src/hooks/history';
+import {
+  useGotoEventEdit,
+  useGotoEventPreview,
+  usePreviewEvent,
+} from 'src/hooks/history';
 import { useEditToken } from 'src/hooks/saved-tokens';
 
 export const PreviewEventContainer = () => {
@@ -22,9 +26,17 @@ export const PreviewEventContainer = () => {
     return <div>Det finnes ingen event å forhåndsvise</div>;
   }
 
-  const participantsText = `0 av ${event.maxParticipants === 0 ? '∞' : event.maxParticipants}${
-    event.hasWaitingList && event.maxParticipants !== 0 ? ' og 0 på venteliste' : ''
+  const participantsText = `0 av ${
+    event.maxParticipants === 0 ? '∞' : event.maxParticipants
+  }${
+    event.hasWaitingList && event.maxParticipants !== 0
+      ? ' og 0 på venteliste'
+      : ''
   }`;
+
+  const returnToEdit = () => {
+    history.goBack();
+  };
 
   const putEditedEvent = catchAndNotify(async () => {
     await putEvent(eventId, event, editToken);
@@ -39,6 +51,9 @@ export const PreviewEventContainer = () => {
       </div>
       <div className={style.buttonContainer}>
         <Button onClick={putEditedEvent}>Oppdater arrangement</Button>
+        <Button color="White" onClick={returnToEdit}>
+          Tilbake til redigering
+        </Button>
       </div>
     </Page>
   );

--- a/app/src/components/PreviewEvent/PreviewEventContainer.tsx
+++ b/app/src/components/PreviewEvent/PreviewEventContainer.tsx
@@ -4,15 +4,11 @@ import { Page } from 'src/components/Page/Page';
 import { useNotification } from 'src/components/NotificationHandler/NotificationHandler';
 import { useHistory } from 'react-router';
 import { useParam } from 'src/utils/browser-state';
-import { editEventRoute, eventIdKey, viewEventRoute } from 'src/routing';
+import { eventIdKey, viewEventRoute } from 'src/routing';
 import { putEvent } from 'src/api/arrangementSvc';
 import { ViewEvent } from 'src/components/ViewEvent/ViewEvent';
 import { Button } from 'src/components/Common/Button/Button';
-import {
-  useGotoEventEdit,
-  useGotoEventPreview,
-  usePreviewEvent,
-} from 'src/hooks/history';
+import { usePreviewEvent } from 'src/hooks/history';
 import { useEditToken } from 'src/hooks/saved-tokens';
 
 export const PreviewEventContainer = () => {

--- a/app/src/components/PreviewEvent/PreviewEventContainer.tsx
+++ b/app/src/components/PreviewEvent/PreviewEventContainer.tsx
@@ -46,10 +46,10 @@ export const PreviewEventContainer = () => {
         <ViewEvent event={event} participantsText={participantsText} />
       </div>
       <div className={style.buttonContainer}>
-        <Button onClick={putEditedEvent}>Oppdater arrangement</Button>
         <Button color="White" onClick={returnToEdit}>
-          Tilbake til redigering
+          Rediger
         </Button>
+        <Button onClick={putEditedEvent}>Oppdater arrangement</Button>
       </div>
     </Page>
   );

--- a/app/src/components/PreviewEvent/PreviewNewEventContainer.tsx
+++ b/app/src/components/PreviewEvent/PreviewNewEventContainer.tsx
@@ -51,8 +51,10 @@ export const PreviewNewEventContainer = () => {
         <ViewEvent event={event} participantsText={participantsText} />
       </div>
       <div className={style.buttonContainer}>
+        <Button onClick={returnToCreate} color="White">
+          Rediger
+        </Button>
         <Button onClick={postNewEvent}>Opprett arrangement</Button>
-        <Button onClick={returnToCreate}>Tilbake til redigering</Button>
       </div>
     </Page>
   );

--- a/app/src/components/PreviewEvent/PreviewNewEventContainer.tsx
+++ b/app/src/components/PreviewEvent/PreviewNewEventContainer.tsx
@@ -21,8 +21,16 @@ export const PreviewNewEventContainer = () => {
     return <div>Det finnes ingen event å forhåndsvise</div>;
   }
 
-  const participantsText = `0 av ${event.maxParticipants === 0 ? '∞' : event.maxParticipants}${
-    event.hasWaitingList && event.maxParticipants !== 0 ? ' og 0 på venteliste' : ''
+  const returnToCreate = () => {
+    history.goBack();
+  };
+
+  const participantsText = `0 av ${
+    event.maxParticipants === 0 ? '∞' : event.maxParticipants
+  }${
+    event.hasWaitingList && event.maxParticipants !== 0
+      ? ' og 0 på venteliste'
+      : ''
   }`;
 
   const postNewEvent = catchAndNotify(async () => {
@@ -44,6 +52,7 @@ export const PreviewNewEventContainer = () => {
       </div>
       <div className={style.buttonContainer}>
         <Button onClick={postNewEvent}>Opprett arrangement</Button>
+        <Button onClick={returnToCreate}>Tilbake til redigering</Button>
       </div>
     </Page>
   );

--- a/app/src/components/ViewEvent/ViewEventContainer.tsx
+++ b/app/src/components/ViewEvent/ViewEventContainer.tsx
@@ -86,7 +86,7 @@ export const ViewEventContainer = () => {
       : undefined;
 
   const numberOfPossibleParticipantsText =
-    event.maxParticipants == 0
+    event.maxParticipants === 0
       ? 'Ubegrenset antall plasser'
       : event.maxParticipants + ' plasser';
 

--- a/app/src/components/ViewEvent/ViewEventContainer.tsx
+++ b/app/src/components/ViewEvent/ViewEventContainer.tsx
@@ -16,10 +16,7 @@ import { BlockLink } from 'src/components/Common/BlockLink/BlockLink';
 import { ViewEvent } from 'src/components/ViewEvent/ViewEvent';
 import { useParam } from 'src/utils/browser-state';
 import { useEvent, useNumberOfParticipants } from 'src/hooks/cache';
-import {
-  useEditToken,
-  useSavedParticipations,
-} from 'src/hooks/saved-tokens';
+import { useEditToken, useSavedParticipations } from 'src/hooks/saved-tokens';
 import { AddParticipant } from 'src/components/ViewEvent/AddParticipant';
 import { ViewParticipants } from 'src/components/ViewEvent/ViewParticipants';
 
@@ -88,12 +85,17 @@ export const ViewEventContainer = () => {
       ? 'Arrangementet er dessverre fullt, men du kan fortsatt bli med på ventelisten!'
       : undefined;
 
+  const numberOfPossibleParticipantsText =
+    event.maxParticipants == 0
+      ? 'Ubegrenset antall plasser'
+      : event.maxParticipants + ' plasser';
+
   return (
     <Page>
       {userIsLoggedIn() && (
         <BlockLink to={eventsRoute}>Til arrangementer</BlockLink>
       )}
-      {(editTokenFound || userIsAdmin()) ? (
+      {editTokenFound || userIsAdmin() ? (
         <BlockLink to={editEventRoute(eventId, editTokenFound)}>
           Rediger arrangement
         </BlockLink>
@@ -107,23 +109,18 @@ export const ViewEventContainer = () => {
       <section>
         <h1 className={style.subHeader}>Påmelding</h1>
         {closedEventText ? (
-          <p className={style.text}>
-            Stengt <br /> {closedEventText}
-          </p>
+          <div>
+            <p>{numberOfPossibleParticipantsText}</p>
+            <p className={style.text}>
+              Påmeldingen er stengt <br /> {closedEventText}
+            </p>
+          </div>
         ) : waitlistText ? (
           <p className={style.text}>{waitlistText}</p>
         ) : null}
-        {!closedEventText && (
-          <AddParticipant
-            eventId={eventId}
-            event={event}
-          />
-        )}
+        {!closedEventText && <AddParticipant eventId={eventId} event={event} />}
         {(editTokenFound || userIsAdmin()) && (
-          <ViewParticipants
-            eventId={eventId}
-            editToken={editTokenFound}
-          />
+          <ViewParticipants eventId={eventId} editToken={editTokenFound} />
         )}
       </section>
     </Page>

--- a/app/src/components/ViewEvents/EventListElement.module.scss
+++ b/app/src/components/ViewEvents/EventListElement.module.scss
@@ -24,6 +24,9 @@
 }
 
 .text {
+  line-height: 25px;
+  margin-left: 5px;
+  margin-right: 5px;
   align-self: center;
 }
 

--- a/app/src/components/ViewEvents/EventListElement.tsx
+++ b/app/src/components/ViewEvents/EventListElement.tsx
@@ -35,9 +35,6 @@ export const EventListElement = ({ eventId, event }: IProps) => {
           stringifyTimeInstanceWithDayName(event.openForRegistrationTime)
         ));
 
-  console.log(event.title);
-  console.log('time left', timeLeft);
-
   const participantText =
     numberOfParticipants !== undefined &&
     (event.maxParticipants === 0


### PR DESCRIPTION
Flere små endringer etter tilbakemelding fra brukere: 
- Lagt til knapp for å gå tilbake til redigering/oppretting av arrangement fra forhåndsvisning. Man kan trykke tilbake i nettleser også, men brukere vet ikke på forhånd om dette vil beholde endringene fra tidligere. 
- Vise "Påmelding åpner tid/dato" på forsiden om påmelding ikke har åpnet enda. Tid vises om det er samme dag og dato vises om det er mer enn 1 dag til. 
- Vise antall plasser på et arrangement dersom påmelding ikke har startet enda. Tidligere så man kun antall plasser etter at påmelding var åpnet, siden dette vistes i samme felt som nedtellingen. 