### PR TITLE
Add action to fix multi date bug

### DIFF
--- a/app/src/components/EditEvent/EditEvent/EditEvent.tsx
+++ b/app/src/components/EditEvent/EditEvent/EditEvent.tsx
@@ -132,7 +132,7 @@ export const EditEvent = ({ eventResult: event, updateEvent }: IProps) => {
                   updateEvent({
                     ...event,
                     ...setStartEndDates(event, [
-                      'set-start',
+                      'set-same-date',
                       { ...event.start, date },
                     ]),
                   })
@@ -385,7 +385,10 @@ export const EditEvent = ({ eventResult: event, updateEvent }: IProps) => {
   );
 };
 
-type Action = ['set-start', EditDateTime] | ['set-end', EditDateTime];
+type Action =
+  | ['set-same-date', EditDateTime]
+  | ['set-start', EditDateTime]
+  | ['set-end', EditDateTime];
 
 type State = {
   start: EditDateTime;
@@ -409,6 +412,8 @@ const setStartEndDates = (
   }
 
   switch (type) {
+    case 'set-same-date':
+      return { start: date, end: date };
     case 'set-start':
       return { start: date, end };
     case 'set-end':


### PR DESCRIPTION
If you changed start-date backwards while having a non-multi-day event,
  the end date would not follow. By having an explicit action for this
  it now works more like you would expect, and the dates should follow
  each other.