### PR TITLE
Rerendering

### DIFF
--- a/app/src/hooks/timeleftHooks.ts
+++ b/app/src/hooks/timeleftHooks.ts
@@ -6,15 +6,21 @@ export const useTimeLeft = (time: Date | false) => {
     calculateTimeLeft(time || new Date())
   );
 
+  const isOpenForRegistration = timeLeft.difference <= 0
+  const registrationIsWithinAnHour = timeLeft.difference < (60 * 60000)
+
   useEffect(() => {
-    if (time && timeLeft.difference > 0) {
+    if (isOpenForRegistration)
+      return;
+
+    if (time && registrationIsWithinAnHour) {
       setTimeLeft(calculateTimeLeft(time));
       const interval = setInterval(() => {
         setTimeLeft(calculateTimeLeft(time));
       }, 500);
       return () => clearInterval(interval);
     }
-  }, [time]);
+  }, [time, isOpenForRegistration, registrationIsWithinAnHour]);
 
   return timeLeft;
 };

--- a/app/src/hooks/timeleftHooks.ts
+++ b/app/src/hooks/timeleftHooks.ts
@@ -7,20 +7,20 @@ export const useTimeLeft = (time: Date | false) => {
   );
 
   const isOpenForRegistration = timeLeft.difference <= 0
-  const registrationIsWithinAnHour = timeLeft.difference < (60 * 60000)
+  const registrationIsWithin12Hours = timeLeft.difference < (60 * 60000 * 12)
 
   useEffect(() => {
     if (isOpenForRegistration)
       return;
 
-    if (time && registrationIsWithinAnHour) {
+    if (time && registrationIsWithin12Hours) {
       setTimeLeft(calculateTimeLeft(time));
       const interval = setInterval(() => {
         setTimeLeft(calculateTimeLeft(time));
       }, 500);
       return () => clearInterval(interval);
     }
-  }, [time, isOpenForRegistration, registrationIsWithinAnHour]);
+  }, [time, isOpenForRegistration, registrationIsWithin12Hours]);
 
   return timeLeft;
 };

--- a/app/src/hooks/timeleftHooks.ts
+++ b/app/src/hooks/timeleftHooks.ts
@@ -7,7 +7,7 @@ export const useTimeLeft = (time: Date | false) => {
   );
 
   useEffect(() => {
-    if (time) {
+    if (time && timeLeft.difference > 0) {
       setTimeLeft(calculateTimeLeft(time));
       const interval = setInterval(() => {
         setTimeLeft(calculateTimeLeft(time));


### PR DESCRIPTION
Denne siden trenger litt re-rendering.
Det fordi den har en countdown og når påmelding åpner så kan man melde seg på uten å oppdatere siden.
Dette er ønsket oppførsel og fungerer fortsatt.

Siden hadde også rerendring for stengte arrangementer, arrangementer som allerede var åpnet for påmelding, eller arrangementer som åpner for registrering om lang tid.

Denne endringen gjør det slik at en side rerendres kun dersom man går inn på den 1 time før påmelding åpner.
Denne verdien kan godt justeres dersom folk går inn mer enn en time i forveien og venter.

Tar gjerne tilbakemelding på om en time høres for lite ut.