### PR TITLE
Hide number of signed up on external events temporarily

### DIFF
--- a/app/src/components/ViewEvent/ViewEvent.tsx
+++ b/app/src/components/ViewEvent/ViewEvent.tsx
@@ -84,7 +84,7 @@ export const ViewEvent = ({
             <LocationIcon color="black" className={style.icon} />
             <p>{event.location}</p>
           </div>
-          {!event.isExternal && (
+          {!event.isExternal && ( // Denne sjekken kan fjernes etter 15.juni
             <div className={style.iconTextContainer}>
               <GentlemanIcon color="black" className={style.icon} />
               {hasOpenedForRegistration ? (

--- a/app/src/components/ViewEvent/ViewEvent.tsx
+++ b/app/src/components/ViewEvent/ViewEvent.tsx
@@ -22,7 +22,7 @@ import {
 } from 'src/types/event';
 import { dateToITime, stringifyTime } from 'src/types/time';
 import style from './ViewEvent.module.scss';
-import {useSetTitle} from "src/hooks/setTitle";
+import { useSetTitle } from 'src/hooks/setTitle';
 
 interface IProps {
   eventId?: string;
@@ -84,19 +84,21 @@ export const ViewEvent = ({
             <LocationIcon color="black" className={style.icon} />
             <p>{event.location}</p>
           </div>
-          <div className={style.iconTextContainer}>
-            <GentlemanIcon color="black" className={style.icon} />
-            {hasOpenedForRegistration ? (
-              <p>{participantsText}</p>
-            ) : (
-              <p>
-                {!isMaxParticipantsLimited(event.maxParticipants)
-                  ? ' ∞'
-                  : maxParticipantsLimit(event.maxParticipants)}{' '}
-                plasser
-              </p>
-            )}
-          </div>
+          {!event.isExternal && (
+            <div className={style.iconTextContainer}>
+              <GentlemanIcon color="black" className={style.icon} />
+              {hasOpenedForRegistration ? (
+                <p>{participantsText}</p>
+              ) : (
+                <p>
+                  {!isMaxParticipantsLimited(event.maxParticipants)
+                    ? ' ∞'
+                    : maxParticipantsLimit(event.maxParticipants)}{' '}
+                  plasser
+                </p>
+              )}
+            </div>
+          )}
           {event.isExternal && userIsLoggedIn() && (
             <div className={style.iconTextContainer}>
               <ExternalIcon color="black" className={style.externalIcon} />

--- a/app/src/components/ViewEvent/ViewEventContainer.tsx
+++ b/app/src/components/ViewEvent/ViewEventContainer.tsx
@@ -315,7 +315,8 @@ export const ViewEventContainer = ({ eventId }: IProps) => {
               </>
             )
           )}
-          {/*{!userIsLoggedIn() && event.isExternal && (
+          {/* Dette skal kommenteres inn igjen 15.juni
+          {!userIsLoggedIn() && event.isExternal && (
             <>
               <div className={style.attendeesTitleContainer}>
                 <h2 className={style.subHeader}>Påmeldte</h2>

--- a/app/src/components/ViewEvent/ViewEventContainer.tsx
+++ b/app/src/components/ViewEvent/ViewEventContainer.tsx
@@ -315,14 +315,14 @@ export const ViewEventContainer = ({ eventId }: IProps) => {
               </>
             )
           )}
-          {!userIsLoggedIn() && event.isExternal && (
+          {/*{!userIsLoggedIn() && event.isExternal && (
             <>
               <div className={style.attendeesTitleContainer}>
                 <h2 className={style.subHeader}>Påmeldte</h2>
               </div>
               <p>{participantsText}</p>
             </>
-          )}
+          )}*/}
         </section>
       </Page>
     </>


### PR DESCRIPTION
Etter forespørsel fra Mats KV er dette en midlertidig quick-fix for å skjule antall påmeldte i toppmenyen og under "meld deg på"-seksjonen dersom arrangementet er eksternt

Toppmeny:
<img width="837" alt="image" src="https://user-images.githubusercontent.com/29568022/171587655-b5d18e57-8ed5-4294-850c-557f9043091a.png">

Fjernet fra påmeldingsseksjonen:
<img width="1078" alt="image" src="https://user-images.githubusercontent.com/29568022/171587684-281bd0ea-8d14-4135-83c7-52ce1dc4d3ab.png">
